### PR TITLE
Update dependencies (Gemnasium auto-update 28de48668211c63f18a16e2e79c382b4e63c2211)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_interaction (3.5.1)
+    active_interaction (3.5.2)
       activemodel (>= 4, < 6)
     activejob (5.0.3)
       activesupport (= 5.0.3)
@@ -62,7 +62,7 @@ GEM
     bson (4.2.1)
     builder (3.2.3)
     byebug (9.0.6)
-    capybara (2.14.0)
+    capybara (2.14.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -161,9 +161,9 @@ GEM
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     modernizr-rails (2.7.1)
-    mongo (2.4.1)
+    mongo (2.4.2)
       bson (>= 4.2.1, < 5.0.0)
-    mongoid (6.1.0)
+    mongoid (6.1.1)
       activemodel (~> 5.0)
       mongo (>= 2.4.1, < 3.0.0)
     multi_json (1.12.1)
@@ -323,7 +323,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS


### PR DESCRIPTION
Update dependencies:
capybara: 2.14.0 => 2.14.1
mongo: 2.4.1 => 2.4.2
mongoid: 6.1.0 => 6.1.1
xpath: 2.0.0 => 2.1.0
active_interaction: 3.5.1 => 3.5.2