### PR TITLE
Update dependencies (Gemnasium auto-update 70a34c4087cb6dcd89c29afe4ab9659aefc3d4ff)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_interaction (3.5.2)
+    active_interaction (3.5.3)
       activemodel (>= 4, < 6)
     activejob (5.0.6)
       activesupport (= 5.0.6)
@@ -42,7 +42,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    appsignal (2.3.4)
+    appsignal (2.3.6)
       rack
     arel (7.1.4)
     ast (2.3.0)
@@ -76,6 +76,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    crass (1.0.2)
     daemons (1.2.4)
     database_cleaner (1.6.1)
     delayed_job (4.1.3)
@@ -150,7 +151,8 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.0.3)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
     mail (2.6.6)
@@ -163,7 +165,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_mime (0.1.4)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     modernizr-rails (2.7.1)
     moneta (0.8.1)
@@ -175,8 +177,8 @@ GEM
     multi_json (1.12.2)
     nenv (0.3.0)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -396,7 +398,7 @@ DEPENDENCIES
   workless_revived
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.4.2p198
 
 BUNDLED WITH
    1.15.4


### PR DESCRIPTION
Update dependencies:
nokogiri: 1.8.0 => 1.8.1
loofah: 2.0.3 => 2.1.1
appsignal: 2.3.4 => 2.3.6
active_interaction: 3.5.2 => 3.5.3
mini_portile2: 2.2.0 => 2.3.0