### PR TITLE
Update dependencies (Gemnasium auto-update 06a3158121fe65a36889bcb088503e0a838a774a)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :test do
   gem 'simplecov'
 
   # Used for gem mocking
-  gem 'factory_girl_rails'
+  gem 'factory_girl_rails', '= 4.8.0'
 
   # Test which template was rendered
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_interaction (3.5.3)
+    active_interaction (3.6.0)
       activemodel (>= 4, < 6)
     active_model_serializers (0.10.6)
       actionpack (>= 4.1, < 6)
@@ -123,7 +123,7 @@ GEM
     erubis (2.7.0)
     excon (0.59.0)
     execjs (2.7.0)
-    factory_girl (4.8.1)
+    factory_girl (4.8.2)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
@@ -299,7 +299,7 @@ GEM
     rspec-support (3.6.0)
     rspec_junit_formatter (0.3.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.50.0)
+    rubocop (0.51.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
@@ -409,7 +409,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   dotenv-rails
-  factory_girl_rails
+  factory_girl_rails (= 4.8.0)
   guard-rspec
   haml-rails
   jbuilder


### PR DESCRIPTION
Update dependencies:
factory_girl_rails: 4.8.0 => 4.8.0
factory_girl: 4.8.1 => 4.8.2
rubocop: 0.50.0 => 0.51.0
active_interaction: 3.5.3 => 3.6.0