### PR TITLE
Update dependencies (Gemnasium auto-update ac7250c75791f81ad91f6cd79ee7c99b2efc335d)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :test do
   gem 'simplecov'
 
   # Used for gem mocking
-  gem 'factory_girl_rails'
+  gem 'factory_girl_rails', '= 4.8.0'
 
   # Test which template was rendered
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_interaction (3.5.3)
+    active_interaction (3.6.0)
       activemodel (>= 4, < 6)
     active_model_serializers (0.10.6)
       actionpack (>= 4.1, < 6)
@@ -107,7 +107,7 @@ GEM
     crass (1.0.2)
     d3-rails (3.5.17)
       railties (>= 3.1)
-    daemons (1.2.4)
+    daemons (1.2.5)
     database_cleaner (1.6.1)
     delayed_job (4.1.3)
       activesupport (>= 3.0, < 5.2)
@@ -269,7 +269,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    react-rails (2.3.1)
+    react-rails (2.4.0)
       babel-transpiler (>= 0.7.0)
       connection_pool
       execjs
@@ -299,7 +299,7 @@ GEM
     rspec-support (3.6.0)
     rspec_junit_formatter (0.3.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.50.0)
+    rubocop (0.51.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
@@ -409,7 +409,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   dotenv-rails
-  factory_girl_rails
+  factory_girl_rails (= 4.8.0)
   guard-rspec
   haml-rails
   jbuilder


### PR DESCRIPTION
Update dependencies:
factory_girl_rails: 4.8.0 => 4.8.0
daemons: 1.2.4 => 1.2.5
rubocop: 0.50.0 => 0.51.0
active_interaction: 3.5.3 => 3.6.0
react-rails: 2.3.1 => 2.4.0