### PR TITLE
Fix security?

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1",
     "react_ujs": "^2.6.0",
+    "serialize-javascript": "^2.1.1",
     "typescript": "^3.5.3",
     "webpack": "^4.39.2",
     "webpack-cli": "^3.3.7"
@@ -34,7 +35,6 @@
     "jest": "^24.9.0",
     "webpack-dev-server": "^3.8.0"
   },
-
   "scripts": {
     "test": "jest"
   },
@@ -51,6 +51,8 @@
       "^.+\\.jsx$": "babel-jest",
       "^.+\\.js$": "babel-jest"
     },
-    "setupFilesAfterEnv": ["./spec/javascript/setupTests.js"]
+    "setupFilesAfterEnv": [
+      "./spec/javascript/setupTests.js"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,7 +967,6 @@
 
 "@rails/webpacker@git+https://github.com/rails/webpacker.git":
   version "4.2.2"
-  uid "5dc3d76828ac83a9c7d059678191e05298e980f2"
   resolved "git+https://github.com/rails/webpacker.git#5dc3d76828ac83a9c7d059678191e05298e980f2"
   dependencies:
     "@babel/core" "^7.7.2"
@@ -8398,6 +8397,11 @@ serialize-javascript@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.0.tgz#9310276819efd0eb128258bb341957f6eb2fc570"
   integrity sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==
+
+serialize-javascript@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
I don't think this works because it still has the older versions of serialize-javascript in the yarn.lock. So maybe remove those and then see if they get added when you do a yarn install, and if not, then it works.