### PR TITLE
Add numerical value for options for use in score calculations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # load docker image & start docker engine
 image: tmaier/docker-compose:latest
 services:
-  - docker:dind
+  - docker:19.03.1-dind
 
 # define pipline stages
 stages:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -207,7 +207,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    i18n-js (3.5.1)
+    i18n-js (3.6.0)
       i18n (>= 0.6.6)
     iban-tools (1.1.0)
     jaro_winkler (1.5.4)
@@ -391,7 +391,7 @@ GEM
     rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.37.1)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)

--- a/README.md
+++ b/README.md
@@ -446,12 +446,12 @@ Required and allowed options (minimal example and maximal example):
   title: 'Aan welke doelen heb je deze week gewerkt tijdens de begeleiding van deze student?',
   tooltip: 'some tooltip',
   options: [
-   { title: 'De relatie verbeteren en/of onderhouden', shows_questions: %i[v2 v3] },
-   { title: 'Inzicht krijgen in de belevingswereld', hides_questions: %i[v4 v5] },
+   { title: 'De relatie verbeteren en/of onderhouden', shows_questions: %i[v2 v3], numeric_value: 20 },
+   { title: 'Inzicht krijgen in de belevingswereld', hides_questions: %i[v4 v5], numeric_value: 40 },
    'Inzicht krijgen in de omgeving',
-   { title: 'Zelfinzicht geven', shows_questions: %i[v8 v9], stop_subscription: true },
-   { title: 'Vaardigheden ontwikkelen', tooltip: 'Zoals wiskunde', shows_questions: %i[v10 v11] },
-   { title: 'De omgeving veranderen/afstemmen met de omgeving', shows_questions: %i[v12] }
+   { title: 'Zelfinzicht geven', shows_questions: %i[v8 v9], stop_subscription: true, numeric_value: 60 },
+   { title: 'Vaardigheden ontwikkelen', tooltip: 'Zoals wiskunde', shows_questions: %i[v10 v11], numeric_value: 80 },
+   { title: 'De omgeving veranderen/afstemmen met de omgeving', shows_questions: %i[v12], numeric_value: 100 }
   ],
   show_otherwise: true,
   otherwise_label: 'Nee, omdat:',
@@ -463,12 +463,20 @@ Required and allowed options (minimal example and maximal example):
 The options array can contain either hashes or strings. 
 If it is just a string, it is used as the `title` element.
 The `show_otherwise` field is optional, and determines whether or not the question should have an 'otherwise' field. 
-The `tooltip' field is also optional. 
+The `tooltip` field is also optional.
 When present, it will introduce a small i on which the user can click to get extra information (the information in the tooltip variable).
 
 Note that the `shows_questions`, `hides_questions`, and `stop_subscription` option properties here work identically to those described above in the Type: Checkbox section.
 
 Radios are always required.
+
+Radios, Likerts, and Dropdowns can have a `numeric_value` property attribute for entries in their `option` array.
+This value can be a float or integer, but the convention is integer, and that the options span a range from 0 to 100.
+In particular, one would want the `numeric_value`s of different questions in the same questionnaire to be in the same scale, so that their average can be calculated in scores.
+The `numeric_value` is the numerical representation of each option, used when combining multiple of this of questions to calculate an average score.
+If the options array spans a consecutive interval whose high values should affect the average negatively (and vice versa),  simply assign numeric_value the options from 100 down to 0 instead of the other way around.
+This attribute is optional, and there is no default value. If the chosen answer option does not have a `numeric_value`, it will be treated as missing for purposes of score calculation.
+Note that this attribute is only a requirement for score calculation, not for distribution calculations. For distribution calculations, we only keep frequency counts per option per question, and we don't combine anything so it doesn't matter that the options themselves aren't numbers.
 
 ### Type: Likert
 Required and allowed options (minimal example and maximal example):
@@ -486,7 +494,13 @@ Required and allowed options (minimal example and maximal example):
   type: :likert,
   title: 'Wat vind u van deze stelling?',
   tooltip: 'some tooltip',
-  options: ['helemaal oneens', 'oneens', 'neutraal', 'eens', 'helemaal eens'],
+  options: [
+    { title: 'helemaal oneens', numeric_value: 1 },
+    { title: 'oneens', numeric_value: 2 },
+    { title: 'neutraal', numeric_value: 3 },
+    { title: 'eens', numeric_value: 4 },
+    { title: 'helemaal eens', numeric_value: 5 }
+  ],
   section_end: true
 }]
 ```
@@ -494,6 +508,15 @@ Required and allowed options (minimal example and maximal example):
 The options array can currently only contain strings. 
 The strings in the array are used as answer options. 
 Likert questions are always required.
+
+Radios, Likerts, and Dropdowns can have a `numeric_value` property attribute for entries in their `option` array.
+This value can be a float or integer, but the convention is integer, and that the options span a range from 0 to 100.
+In particular, one would want the `numeric_value`s of different questions in the same questionnaire to be in the same scale, so that their average can be calculated in scores.
+The `numeric_value` is the numerical representation of each option, used when combining multiple of this of questions to calculate an average score.
+If the options array spans a consecutive interval whose high values should affect the average negatively (and vice versa),  simply assign numeric_value the options from 100 down to 0 instead of the other way around.
+This attribute is optional, and there is no default value. If the chosen answer option does not have a `numeric_value`, it will be treated as missing for purposes of score calculation.
+Note that this attribute is only a requirement for score calculation, not for distribution calculations. For distribution calculations, we only keep frequency counts per option per question, and we don't combine anything so it doesn't matter that the options themselves aren't numbers.
+
 
 ### Type: Range
 Required and allowed options (minimal example and maximal example):
@@ -780,7 +803,13 @@ Required and allowed options (minimal example and maximal example):
   title: 'Aan welke doelen heb je deze week gewerkt tijdens de begeleiding van deze student?',
   label: 'RMC regio',
   tooltip: 'some tooltip',
-  options: ['hobby/sport', 'werk', 'vriendschap', 'romantische relatie', 'thuis'],
+  options: [
+    { title: 'hobby/sport', numeric_value: 0 },
+    { title: 'werk', numeric_value: 25 },
+    { title: 'vriendschap', numeric_value: 50 },
+    { title: 'romantische relatie', numeric_value: 75 },
+    { title: 'thuis', numeric_value: 100 }
+  ],
   section_end: true
 }]
 ```
@@ -801,6 +830,14 @@ The `tooltip' field is optional.
 When present, it will introduce a small i on which the user can click to get extra information (the information in the tooltip variable).
 
 Note that the `shows_questions`, `hides_questions`, and `stop_subscription` option properties here work identically to those described above in the Type: Checkbox section.
+
+Radios, Likerts, and Dropdowns can have a `numeric_value` property attribute for entries in their `option` array.
+This value can be a float or integer, but the convention is integer, and that the options span a range from 0 to 100.
+In particular, one would want the `numeric_value`s of different questions in the same questionnaire to be in the same scale, so that their average can be calculated in scores.
+The `numeric_value` is the numerical representation of each option, used when combining multiple of this of questions to calculate an average score.
+If the options array spans a consecutive interval whose high values should affect the average negatively (and vice versa),  simply assign numeric_value the options from 100 down to 0 instead of the other way around.
+This attribute is optional, and there is no default value. If the chosen answer option does not have a `numeric_value`, it will be treated as missing for purposes of score calculation.
+Note that this attribute is only a requirement for score calculation, not for distribution calculations. For distribution calculations, we only keep frequency counts per option per question, and we don't combine anything so it doesn't matter that the options themselves aren't numbers.
 
 ### Type: Drawing
 Let's a user draw on an image. 

--- a/app/assets/stylesheets/questionnaire.scss
+++ b/app/assets/stylesheets/questionnaire.scss
@@ -53,7 +53,10 @@
 }
 
 input[type=range] {
-  margin-top: 26px;
+  margin-top: 11px;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  margin-bottom: 0;
 }
 
 // Note: It doesn't work in Chrome (and possibly other browsers)

--- a/app/controllers/token_authentication_controller.rb
+++ b/app/controllers/token_authentication_controller.rb
@@ -31,6 +31,8 @@ class TokenAuthenticationController < ApplicationController
   def store_person_cookie(identifier)
     cookie = { PERSON_ID_COOKIE => identifier }
     CookieJar.set_or_update_cookie(cookies.signed, cookie)
+    # Remove the JWTAuthenticator cookie if set, so we log out any other sessions on this browser.
+    CookieJar.delete_cookie(cookies.signed, JWT_TOKEN_COOKIE)
     store_verification_cookie
   end
 

--- a/app/generators/dropdown_generator.rb
+++ b/app/generators/dropdown_generator.rb
@@ -29,9 +29,13 @@ class DropdownGenerator < QuestionTypeGenerator
     placeholder = question[:placeholder] || DROPDOWN_PLACEHOLDER
     body << content_tag(:option, placeholder, disabled: true, selected: true, value: '')
     question[:options].each_with_index do |option, idx|
-      body << content_tag(:option, option, value: question[:raw][:options][idx])
+      body << dropdown_option_body(add_raw_to_option(option, question, idx))
     end
     body = safe_join(body)
     content_tag(:select, body, name: answer_name(id), id: id, required: true, class: 'browser-default')
+  end
+
+  def dropdown_option_body(option)
+    content_tag(:option, option[:title].html_safe, value: option[:raw][:title])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,8 +12,9 @@ module ApplicationHelper
     return @current_user if @current_user.present?
 
     @current_user ||= current_user_from_header
+    @current_user ||= JwtAuthenticator.auth_from_params(cookies.signed, params)
     @current_user ||= TokenAuthenticator.auth(cookies.signed, params)
-    @current_user ||= JwtAuthenticator.auth(cookies.signed, params)
+    @current_user ||= JwtAuthenticator.auth_from_cookies(cookies.signed)
     @current_user
   end
 

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -52,7 +52,6 @@ module DistributionHelper
   end
 
   def number_to_string(num)
-    Float(num)
     i = num.to_i
     f = num.to_f
     i == f ? i.to_s : f.to_s

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -12,6 +12,11 @@ module DistributionHelper
   # context, hence there is no specific test suite for this file.
   def usable_questions
     @questionnaire_content = questionnaire.content
+    # If there are old questionnaires in the system that no longer have seeds
+    # attached to them and are still in the old format, just leave them alone.
+    return [] unless @questionnaire_content.is_a?(Hash) &&
+                     @questionnaire_content.key?(:questions) && @questionnaire_content.key?(:scores)
+
     range_questions(@questionnaire_content[:questions]) +
       other_questions(@questionnaire_content[:questions]) +
       scores(@questionnaire_content[:scores])
@@ -46,6 +51,15 @@ module DistributionHelper
     end
   end
 
+  def number_to_string(num)
+    Float(num)
+    i = num.to_i
+    f = num.to_f
+    i == f ? i.to_s : f.to_s
+  rescue ArgumentError
+    num.to_s
+  end
+
   def initialize_question(question, value, distribution)
     qid = question[:id]
     return if distribution[qid].present? && question[:type] == :range
@@ -56,7 +70,9 @@ module DistributionHelper
       return
     end
 
-    (question[:min]..question[:max]).step(question[:step]) { |pos| distribution[qid][pos.to_s] = { VALUE => 0 } }
+    (question[:min]..question[:max]).step(question[:step]) do |pos|
+      distribution[qid][number_to_string(pos)] = { VALUE => 0 }
+    end
   end
 
   def process_response_ids(response_ids)

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -75,9 +75,10 @@ module DistributionHelper
   end
 
   def process_response_ids(response_ids)
-    ResponseContent.where(:id.in => response_ids).pluck(:content).each do |content|
+    ResponseContent.where(:id.in => response_ids).pluck(:content, :enriched_content).each do |content, enriched_content|
+      all_content = content.merge(enriched_content)
       @usable_questions.each do |question|
-        add_to_distribution(question, content, @distribution)
+        add_to_distribution(question, all_content, @distribution)
       end
     end
   end

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -76,7 +76,9 @@ module DistributionHelper
 
   def process_response_ids(response_ids)
     ResponseContent.where(:id.in => response_ids).pluck(:content, :scores).each do |content, scores|
-      all_content = content.merge(scores)
+      next if content.nil? # Can theoretically happen
+
+      all_content = scores.present? ? content.merge(scores) : content
       @usable_questions.each do |question|
         add_to_distribution(question, all_content, @distribution)
       end

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -75,8 +75,8 @@ module DistributionHelper
   end
 
   def process_response_ids(response_ids)
-    ResponseContent.where(:id.in => response_ids).pluck(:content, :enriched_content).each do |content, enriched_content|
-      all_content = content.merge(enriched_content)
+    ResponseContent.where(:id.in => response_ids).pluck(:content, :scores).each do |content, scores|
+      all_content = content.merge(scores)
       @usable_questions.each do |question|
         add_to_distribution(question, all_content, @distribution)
       end

--- a/app/jobs/recalculate_scores_job.rb
+++ b/app/jobs/recalculate_scores_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RecalculateScoresJob < ApplicationJob
+  queue_as :default
+
+  def perform(questionnaire_id)
+    questionnaire = Questionnaire.find(questionnaire_id)
+    return if questionnaire.blank?
+
+    RecalculateScores.run!(questionnaire: questionnaire)
+  end
+
+  def max_attempts
+    2
+  end
+
+  def reschedule_at(current_time, _attempts)
+    current_time + 5.minutes
+  end
+end

--- a/app/logic/jwt_authenticator.rb
+++ b/app/logic/jwt_authenticator.rb
@@ -50,6 +50,9 @@ class JwtAuthenticator
     def store_token_in_cookie(token, cookies)
       cookie = { TokenAuthenticationController::JWT_TOKEN_COOKIE => token }
       CookieJar.set_or_update_cookie(cookies, cookie)
+      # Remove the TokenAuthenticator cookie if set, so that when the token is no
+      # longer in the params, we still end up with the JWT token login.
+      CookieJar.delete_cookie(cookies, TokenAuthenticationController::PERSON_ID_COOKIE)
     end
   end
 end

--- a/app/logic/token_authenticator.rb
+++ b/app/logic/token_authenticator.rb
@@ -2,9 +2,9 @@
 
 class TokenAuthenticator
   class << self
-    def auth(cookies, _params)
-      person_external_identifier = CookieJar.read_entry(cookies, TokenAuthenticationController::PERSON_ID_COOKIE)
-      Person.find_by(external_identifier: person_external_identifier)
+    def auth(cookies_signed, _params)
+      person_external_identifier = CookieJar.read_entry(cookies_signed, TokenAuthenticationController::PERSON_ID_COOKIE)
+      Person.find_by(external_identifier: person_external_identifier) if person_external_identifier
     end
   end
 end

--- a/app/models/auth_user.rb
+++ b/app/models/auth_user.rb
@@ -34,7 +34,7 @@ class AuthUser < ApplicationRecord
       email = email_from_payload(payload)
       auth_user = nil
 
-      RedisMutex.with_lock("CreateAnonymousUser:#{id}") do
+      RedisMutex.with_lock("CreateAnonymousUser:#{id}", block: 5) do
         auth_user = CreateAnonymousUser.run!(
           auth0_id_string: id,
           team_name: team,

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -56,6 +56,13 @@ class Questionnaire < ApplicationRecord
     content[:questions].select { |question| question[:type]&.to_sym == :drawing }.map { |question| question[:id] }
   end
 
+  def recalculate_scores!
+    # if there are no completed responses, we don't need to recalculate scores
+    return if responses.completed.count.zero?
+
+    RecalculateScoresJob.perform_later(id)
+  end
+
   private
 
   def questionnaire_structure

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -125,9 +125,9 @@ class Response < ApplicationRecord
 
   def values
     rcontent = remote_content
-    return rcontent&.content if rcontent&.content.nil? || rcontent&.enriched_content.blank?
+    return rcontent&.content if rcontent&.content.nil? || rcontent&.scores.blank?
 
-    rcontent&.content&.merge(rcontent&.enriched_content)
+    rcontent&.content&.merge(rcontent&.scores)
   end
 
   def expired?

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -124,7 +124,10 @@ class Response < ApplicationRecord
   end
 
   def values
-    remote_content&.content
+    rcontent = remote_content
+    return rcontent&.content if rcontent&.content.nil? || rcontent&.enriched_content.blank?
+
+    rcontent&.content&.merge(rcontent&.enriched_content)
   end
 
   def expired?

--- a/app/models/response_content.rb
+++ b/app/models/response_content.rb
@@ -4,13 +4,13 @@ class ResponseContent
   include Mongoid::Document
   include Mongoid::Timestamps
   field :content, type: Hash
-  field :enriched_content, type: Hash
+  field :scores, type: Hash
 
   class << self
     def create_with_scores!(content:, response:)
       questionnaire = response.measurement.questionnaire.content
-      enriched_content = EnrichContent.run!(content: content, questionnaire: questionnaire)
-      create!(content: content, enriched_content: enriched_content)
+      scores = CalculateScores.run!(content: content, questionnaire: questionnaire)
+      create!(content: content, scores: scores)
     end
   end
 end

--- a/app/models/response_content.rb
+++ b/app/models/response_content.rb
@@ -4,12 +4,13 @@ class ResponseContent
   include Mongoid::Document
   include Mongoid::Timestamps
   field :content, type: Hash
+  field :enriched_content, type: Hash
 
   class << self
     def create_with_scores!(content:, response:)
       questionnaire = response.measurement.questionnaire.content
       enriched_content = EnrichContent.run!(content: content, questionnaire: questionnaire)
-      create!(content: enriched_content)
+      create!(content: content, enriched_content: enriched_content)
     end
   end
 end

--- a/app/models/response_content.rb
+++ b/app/models/response_content.rb
@@ -3,8 +3,8 @@
 class ResponseContent
   include Mongoid::Document
   include Mongoid::Timestamps
-  field :content, type: Hash
-  field :scores, type: Hash
+  field :content, type: Hash, default: {}
+  field :scores, type: Hash, default: {}
 
   class << self
     def create_with_scores!(content:, response:)

--- a/app/tools/cookie_jar.rb
+++ b/app/tools/cookie_jar.rb
@@ -25,6 +25,8 @@ class CookieJar
       return false if entry.nil? || cookie.nil?
 
       cookie = JSON.parse(cookie)
+      cookie = {} unless cookie.is_a?(Hash)
+      cookie = cookie.with_indifferent_access
       cookie[entry.to_s]
     end
 
@@ -34,9 +36,23 @@ class CookieJar
       if current_cookie.present?
         current_cookie = JSON.parse(current_cookie)
         current_cookie = {} unless current_cookie.is_a?(Hash)
+        current_cookie = current_cookie.with_indifferent_access
         cookie_hash = current_cookie.merge(cookie_hash)
       end
       jar[COOKIE_LOCATION] = cookie_hash.to_json
+    end
+
+    def delete_cookie(jar, key)
+      current_cookie = jar[COOKIE_LOCATION]
+      return if current_cookie.blank?
+
+      current_cookie = JSON.parse(current_cookie)
+      current_cookie = {} unless current_cookie.is_a?(Hash)
+      current_cookie = current_cookie.with_indifferent_access
+      return unless current_cookie.key?(key)
+
+      current_cookie.delete(key)
+      jar[COOKIE_LOCATION] = current_cookie.to_json
     end
   end
 end

--- a/app/use_cases/create_anonymous_user.rb
+++ b/app/use_cases/create_anonymous_user.rb
@@ -37,7 +37,8 @@ class CreateAnonymousUser < ActiveInteraction::Base
       person = Person.find_by(email: email_address)
       if person.present? && person.auth_user.blank?
         ActiveRecord::Base.transaction do
-          person.update!(auth_user: auth_user, email: nil, role: find_role, account_active: true)
+          person.update!(auth_user: auth_user, email: nil, role: find_role,
+                         account_active: Rails.application.config.settings.account_active_default)
           auth_user.person = person
           auth_user.save!
         end
@@ -54,7 +55,7 @@ class CreateAnonymousUser < ActiveInteraction::Base
                              gender: nil,
                              mobile_phone: nil,
                              role: find_role,
-                             account_active: true)
+                             account_active: Rails.application.config.settings.account_active_default)
     auth_user
   end
 

--- a/app/use_cases/enrich_content.rb
+++ b/app/use_cases/enrich_content.rb
@@ -61,6 +61,9 @@ class EnrichContent < ActiveInteraction::Base
     @enriched_content[score[:id].to_s] = value.to_s
   rescue EnrichMissingDataError
     # This just means the score won't be calculated
+    # Remove the score if it exists (in case the score calculation was updated,
+    # we don't want to be left with old scores).
+    @enriched_content.delete(score[:id].to_s)
     nil
   end
 

--- a/app/use_cases/recalculate_scores.rb
+++ b/app/use_cases/recalculate_scores.rb
@@ -24,6 +24,8 @@ class RecalculateScores < ActiveInteraction::Base
 
   def recalculate_response_ids(response_ids)
     ResponseContent.where(:id.in => response_ids).pluck(:content, :id).each do |content, rcid|
+      next if content.nil? # Can theoretically happen
+
       scores = CalculateScores.run!(content: content, questionnaire: @questionnaire_content)
       ResponseContent.find(rcid)&.update!(scores: scores)
     end

--- a/app/use_cases/recalculate_scores.rb
+++ b/app/use_cases/recalculate_scores.rb
@@ -24,8 +24,8 @@ class RecalculateScores < ActiveInteraction::Base
 
   def recalculate_response_ids(response_ids)
     ResponseContent.where(:id.in => response_ids).pluck(:content, :id).each do |content, rcid|
-      enriched_content = EnrichContent.run!(content: content, questionnaire: @questionnaire_content)
-      ResponseContent.find(rcid)&.update!(enriched_content: enriched_content)
+      scores = CalculateScores.run!(content: content, questionnaire: @questionnaire_content)
+      ResponseContent.find(rcid)&.update!(scores: scores)
     end
   end
 

--- a/app/use_cases/recalculate_scores.rb
+++ b/app/use_cases/recalculate_scores.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class RecalculateScores < ActiveInteraction::Base
+  BATCH_SIZE = 200
+  object :questionnaire
+
+  # Recalculates the scores for a questionnaire
+  #
+  # @param questionnaire [Questionnaire] the current questionnaire
+  def execute
+    @questionnaire_content = questionnaire.content
+    offset = 0
+    loop do
+      response_ids = questionnaire.responses.completed.limit(BATCH_SIZE).offset(offset).pluck(:content)
+      break if response_ids.blank?
+
+      recalculate_response_ids(response_ids)
+      offset += BATCH_SIZE
+    end
+    recalculate_distribution
+  end
+
+  private
+
+  def recalculate_response_ids(response_ids)
+    ResponseContent.where(:id.in => response_ids).pluck(:content, :id).each do |content, rcid|
+      enriched_content = EnrichContent.run!(content: content, questionnaire: @questionnaire_content)
+      ResponseContent.find(rcid)&.update!(content: enriched_content) if enriched_content != content
+    end
+  end
+
+  def recalculate_distribution
+    # Recalculate the distribution for this questionnaire if there are completed responses
+    response_id = questionnaire.responses.completed.limit(1).pluck(:id).first
+    return if response_id.blank?
+
+    CalculateDistributionJob.perform_later(response_id)
+  end
+end

--- a/app/use_cases/recalculate_scores.rb
+++ b/app/use_cases/recalculate_scores.rb
@@ -25,7 +25,7 @@ class RecalculateScores < ActiveInteraction::Base
   def recalculate_response_ids(response_ids)
     ResponseContent.where(:id.in => response_ids).pluck(:content, :id).each do |content, rcid|
       enriched_content = EnrichContent.run!(content: content, questionnaire: @questionnaire_content)
-      ResponseContent.find(rcid)&.update!(content: enriched_content) if enriched_content != content
+      ResponseContent.find(rcid)&.update!(enriched_content: enriched_content)
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,7 @@ default: &default
   project_title: <%=ENV['PROJECT_NAME']%>
   metadata_field: <%=ENV['SITE_LOCATION']%>
   default_team_name: 'Controlegroep'
+  account_active_default: true
   hide_edit_iban: false
   show_mobile_images: true
   hide_logo: false

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           - name: APPSIGNAL_PUSH_API_KEY
             valueFrom:
               secretKeyRef:
-                name: base-platform-secret
+                name: svc-questionnaires-secret
                 key: __CI_COMMIT_REF_NAME___APPSIGNAL_PUSH_API_KEY
           - name: PUSH_SUBSCRIPTION_URL
             valueFrom:

--- a/manifests/worker.yaml
+++ b/manifests/worker.yaml
@@ -44,7 +44,7 @@ spec:
           - name: APPSIGNAL_PUSH_API_KEY
             valueFrom:
               secretKeyRef:
-                name: base-platform-secret
+                name: svc-questionnaires-secret
                 key: __CI_COMMIT_REF_NAME___APPSIGNAL_PUSH_API_KEY
           - name: PUSH_SUBSCRIPTION_URL
             valueFrom:

--- a/projects/ikia/seeds/questionnaires/kinderen/kinderen_krachten_10_plus.rb
+++ b/projects/ikia/seeds/questionnaires/kinderen/kinderen_krachten_10_plus.rb
@@ -285,25 +285,25 @@ Vul het woord in bij het daarvoor bedoelde tekstvak. Als je het antwoord niet we
     id: :v4_3,
     required: true,
     type: :range,
-    title: ' Ik houd mezelf bezig zodat ik mijn gedachten of gevoelens niet op merk.',
+    title: 'Ik houd mezelf bezig zodat ik mijn gedachten of gevoelens niet op merk.',
     labels: ['Nooit waar', 'Soms waar', 'Altijd waar']
   }, {
     id: :v4_4,
     type: :range,
     required: true,
-    title: ' Ik zeg tegen mezelf dat ik me niet zo zou moeten voelen zoals ik me voel.',
+    title: 'Ik zeg tegen mezelf dat ik me niet zo zou moeten voelen zoals ik me voel.',
     labels: ['Nooit waar', 'Soms waar', 'Altijd waar']
   }, {
     id: :v4_5,
     type: :range,
     required: true,
-    title: ' Ik druk gedachten weg die ik niet prettig vind.',
+    title: 'Ik druk gedachten weg die ik niet prettig vind.',
     labels: ['Nooit waar', 'Soms waar', 'Altijd waar']
   }, {
     id: :v4_6,
     type: :range,
     required: true,
-    title: ' Het is moeilijk voor mij om mijn aandacht op één ding tegelijk te richten.',
+    title: 'Het is moeilijk voor mij om mijn aandacht op één ding tegelijk te richten.',
     labels: ['Nooit waar', 'Soms waar', 'Altijd waar']
   }, {
     id: :v4_7,
@@ -327,7 +327,7 @@ Vul het woord in bij het daarvoor bedoelde tekstvak. Als je het antwoord niet we
     id: :v4_10,
     type: :range,
     required: true,
-    title: ' Ik hou mezelf tegen in het hebben van gevoelens die ik niet prettig vind.',
+    title: 'Ik hou mezelf tegen in het hebben van gevoelens die ik niet prettig vind.',
     labels: ['Nooit waar', 'Soms waar', 'Altijd waar'],
     section_end: true
   }, {

--- a/projects/ikia/seeds/questionnaires/ouders/ouders_emoties_kind.rb
+++ b/projects/ikia/seeds/questionnaires/ouders/ouders_emoties_kind.rb
@@ -130,6 +130,20 @@ dagboek_content = [
     required: true
   }
 ]
-dagboek1.content = { questions: dagboek_content, scores: [] }
+dagboek1.content = {
+  questions: dagboek_content,
+  scores: [
+    { id: :s1,
+      label: 'Positieve emoties',
+      ids: %i[v1 v3 v5 v6 v8 v11 v13 v14 v15 v19],
+      operation: :average,
+      round_to_decimals: 0 },
+    { id: :s2,
+      label: 'Negatieve emoties',
+      ids: %i[v2 v4 v7 v9 v10 v12 v16 v17 v18 v20],
+      operation: :average,
+      round_to_decimals: 0 }
+  ]
+}
 dagboek1.title = db_title
 dagboek1.save!

--- a/projects/ikia/seeds/questionnaires/ouders/ouders_opvoeding.rb
+++ b/projects/ikia/seeds/questionnaires/ouders/ouders_opvoeding.rb
@@ -4,6 +4,13 @@ db_name1 = 'Opvoeding_Ouderrapportage'
 dagboek1 = Questionnaire.find_by_key(File.basename(__FILE__)[0...-3])
 dagboek1 ||= Questionnaire.new(key: File.basename(__FILE__)[0...-3])
 dagboek1.name = db_name1
+likert_options = [
+  { title: 'Nooit', numeric_value: 0 },
+  { title: 'Bijna nooit', numeric_value: 25 },
+  { title: 'Soms', numeric_value: 50 },
+  { title: 'Vaak', numeric_value: 75 },
+  { title: 'Altijd', numeric_value: 100 }
+]
 dagboek_content = [
   {
     type: :raw,
@@ -12,173 +19,173 @@ dagboek_content = [
     id: :v1,
     type: :likert,
     title: ' Ik toon genegenheid door mijn kind te knuffelen, te zoenen en vast te houden ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v2,
     type: :likert,
     title: 'Als mijn kind zeurt omdat hij/zij iets niet mag, geef ik toe',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v3,
     type: :likert,
     title: 'Ik ben bang dat mijn kind mij niet meer leuk vindt als ik hem/haar corrigeer voor slecht gedrag. ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v4,
     type: :likert,
     title: 'Ik kibbel met mijn kind.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v5,
     type: :likert,
     title: 'Ik dreig met straf zonder hier een duidelijke reden voor te geven. ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v6,
     type: :likert,
     title: 'De straf die ik mijn kind geef hangt af van mijn stemming. ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v7,
     type: :likert,
     title: 'Ik deel warme en intieme momenten met mijn kind.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v8,
     type: :likert,
     title: 'Ik gil of schreeuw wanneer mijn kind zich misdraagt. ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v9,
     type: :likert,
     title: 'Wanneer ik mijn kind wil straffen als hij/zij zich misdraagt, kan hij/zij mij overhalen om dit niet te doen. ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v10,
     type: :likert,
     title: 'Ik toon respect voor de mening van mijn kind door hem/haar aan te moedigen deze te uiten.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v11,
     type: :likert,
     title: 'Als mijn kind zijn/haar taken doet laat ik zien dat ik zijn/haar gedrag opmerk. ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v12,
     type: :likert,
     title: 'Ik beëindig de straf van mijn kind vroegtijdig (bijvoorbeeld eerder dan ik had gezegd). ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v13,
     type: :likert,
     title: 'Ik barst in woede uit tegen mijn kind. ',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v14,
     type: :likert,
     title: 'Ik geef mijn kind een tik wanneer hij/zij iets verkeerd heeft gedaan.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v15,
     type: :likert,
     title: 'Als ik iets van mijn kind vraag, geef ik hier een reden voor (bijvoorbeeld: “We gaan over vijf minuten weg dus het is tijd om op te ruimen”).',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v16,
     type: :likert,
     title: 'Ik verlies mijn kalmte wanneer mijn kind niet doet wat ik hem/haar gevraagd heb.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v17,
     type: :likert,
     title: 'Ik moedig mijn kind aan om over zijn/haar problemen te praten.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v18,
     type: :likert,
     title: 'Als mijn kind doet wat ik hem/haar gevraagd heb geef ik hem/haar een compliment voor het luisteren.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v19,
     type: :likert,
     title: 'Ik geef mijn kind van tevoren een seintje als we iets anders gaan doen (bijvoorbeeld een waarschuwing dat we over vijf minuten van huis vertrekken).',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd'],
+    options: likert_options,
     required: true
   }, {
     id: :v20,
     type: :likert,
     title: 'Als mijn kind overstuur raakt wanneer ik hem/haar iets weiger, krabbel ik terug en geef ik toch toe.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v21,
     type: :likert,
     title: 'Mijn kind en ik knuffelen elkaar en/of geven elkaar zoenen.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v22,
     type: :likert,
     title: 'Ik luister naar de ideeën en meningen van mijn kind.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v23,
     type: :likert,
     title: 'Het is voor mijn gevoel te veel gedoe om mijn kind zover te krijgen dat hij/zij naar mij luistert.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v24,
     type: :likert,
     title: 'Ik geef mijn kind een tik wanneer ik heel erg boos ben.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v25,
     type: :likert,
     title: 'Ik gebruik lichamelijke straffen (zoals een tik geven) om mijn kind te corrigeren.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v26,
     type: :likert,
     title: 'Als mijn kind zijn/haar kamer opruimt laat ik hem/haar weten hoe trots ik ben.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v27,
     type: :likert,
     title: 'Ik geef toe aan mijn kind als hij/zij ergens heisa over maakt.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v28,
     type: :likert,
     title: 'Ik vertel mijn kind hoe ik verwacht dat hij/zij zich zal gedragen voordat hij/zij ergens mee bezig gaat.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v29,
     type: :likert,
     title: 'Wanneer ik overstuur ben of last heb van stress, word ik kritisch en streng tegen mijn kind.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v30,
     type: :likert,
     title: 'Ik laat mijn kind weten dat ik het fijn vind wanneer hij/zij meehelpt in huis.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v31,
     type: :likert,
     title: 'Ik gebruik lichamelijke straffen (zoals een tik geven) omdat andere dingen die ik heb geprobeerd niet hebben gewerkt.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v32,
     type: :likert,
     title: 'Wanneer ik mijn kind corrigeer voor zijn/haar gedrag leg ik kort uit waarom.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v33,
     type: :likert,
     title: 'Ik vermijd strijd met mijn kind door hem/haar duidelijke keuzes te geven.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     id: :v34,
     type: :likert,
     title: 'Wanneer mijn kind zich misdraagt, laat ik hem/haar weten wat er zal gebeuren als hij/zij zich niet gaat gedragen.',
-    options: ['Nooit', 'Bijna nooit', 'Soms', 'Vaak', 'Altijd']
+    options: likert_options
   }, {
     section_start: ' De volgende vragen gaan over hoe u de opvoeding en de relatie met uw kind ervaart. Geef voor elke uitspraak aan in hoeverre deze voor u geldt door het bolletje te verplaatsen.',
     id: :v35,

--- a/projects/ikia/seeds/questionnaires/ouders/ouders_opvoeding.rb
+++ b/projects/ikia/seeds/questionnaires/ouders/ouders_opvoeding.rb
@@ -264,6 +264,25 @@ vanwege mijn kind.',
     section_end: true
   }
 ]
-dagboek1.content = { questions: dagboek_content, scores: [] }
+dagboek1.content = {
+  questions: dagboek_content,
+  scores: [
+    { id: :s1,
+      label: 'Warmte',
+      ids: %i[v1 v7 v21],
+      operation: :average,
+      round_to_decimals: 0 },
+    { id: :s2,
+      label: 'Loslaten',
+      ids: %i[v2 v3 v9 v12 v20 v23 v27],
+      operation: :average,
+      round_to_decimals: 0 },
+    { id: :s3,
+      label: 'Positieve bekrachtiging',
+      ids: %i[v11 v18 v26 v30],
+      operation: :average,
+      round_to_decimals: 0 }
+  ]
+}
 dagboek1.title = db_title
 dagboek1.save!

--- a/projects/ikia/seeds/questionnaires/ouders/ouders_opvoeding.rb
+++ b/projects/ikia/seeds/questionnaires/ouders/ouders_opvoeding.rb
@@ -18,7 +18,7 @@ dagboek_content = [
   }, {
     id: :v1,
     type: :likert,
-    title: ' Ik toon genegenheid door mijn kind te knuffelen, te zoenen en vast te houden ',
+    title: 'Ik toon genegenheid door mijn kind te knuffelen, te zoenen en vast te houden ',
     options: likert_options
   }, {
     id: :v2,
@@ -187,7 +187,7 @@ dagboek_content = [
     title: 'Wanneer mijn kind zich misdraagt, laat ik hem/haar weten wat er zal gebeuren als hij/zij zich niet gaat gedragen.',
     options: likert_options
   }, {
-    section_start: ' De volgende vragen gaan over hoe u de opvoeding en de relatie met uw kind ervaart. Geef voor elke uitspraak aan in hoeverre deze voor u geldt door het bolletje te verplaatsen.',
+    section_start: 'De volgende vragen gaan over hoe u de opvoeding en de relatie met uw kind ervaart. Geef voor elke uitspraak aan in hoeverre deze voor u geldt door het bolletje te verplaatsen.',
     id: :v35,
     type: :range,
     title: 'Ik voel me gelukkig met mijn kind.',

--- a/projects/ikia/seeds/questionnaires/ouders/ouders_welbevinden_kind.rb
+++ b/projects/ikia/seeds/questionnaires/ouders/ouders_welbevinden_kind.rb
@@ -25,7 +25,7 @@ dagboek_content = [
     required: true,
     section_end: true
   }, {
-    section_start: ' De volgende vragen gaan over de vriendschappen van uw kind.',
+    section_start: 'De volgende vragen gaan over de vriendschappen van uw kind.',
     id: :v3,
     type: :range,
     title: 'Mijn kind is tevreden met zijn/haar vrienden of vriendinnen.',

--- a/projects/ikia/seeds/questionnaires/ouders/ouders_welbevinden_zelf.rb
+++ b/projects/ikia/seeds/questionnaires/ouders/ouders_welbevinden_zelf.rb
@@ -14,7 +14,7 @@ dagboek_content = [
     section_start: 'De volgende vragen gaan over uw leven in het algemeen:',
     id: :v1,
     type: :range,
-    title: ' Voelt u zich in het algemeen gelukkig?',
+    title: 'Voelt u zich in het algemeen gelukkig?',
     tooltip: 'Geef een globale inschatting, hoe u zich in het algemeen voelt (dus niet hoe u zich op dit moment voelt',
     labels: ['Nooit', 'Altijd'],
     required: true,
@@ -58,13 +58,13 @@ dagboek_content = [
   }, {
     id: :v8,
     type: :range,
-    title: ' In hoeverre leeft u een nuttig en betekenisvol leven?',
+    title: 'In hoeverre leeft u een nuttig en betekenisvol leven?',
     labels: ['Helemaal niet', 'Volledig'],
     required: true
   }, {
     id: :v9,
     type: :range,
-    title: ' Krijgt u hulp en steun van anderen wanneer u dit nodig hebt?',
+    title: 'Krijgt u hulp en steun van anderen wanneer u dit nodig hebt?',
     labels: ['Helemaal niet', 'Volledig'],
     required: true
   }, {
@@ -136,7 +136,7 @@ dagboek_content = [
   }, {
     id: :v21,
     type: :range,
-    title: ' In hoeverre heeft u een gevoel van richting in uw leven?',
+    title: 'In hoeverre heeft u een gevoel van richting in uw leven?',
     labels: ['Helemaal niet', 'Volledig'],
     required: true
   }, {
@@ -469,6 +469,25 @@ dagboek_content = [
     required: true,
     section_end: true
   }]
-dagboek1.content = { questions: dagboek_content, scores: [] }
+dagboek1.content = {
+  questions: dagboek_content,
+  scores: [
+    { id: :s1,
+      label: 'Positieve emoties',
+      ids: %i[v4 v14 v23],
+      operation: :average,
+      round_to_decimals: 0 },
+    { id: :s2,
+      label: 'Betekenis',
+      ids: %i[v8 v10 v21],
+      operation: :average,
+      round_to_decimals: 0 },
+    { id: :s3,
+      label: 'Voldoening',
+      ids: %i[v2 v6 v16],
+      operation: :average,
+      round_to_decimals: 0 }
+  ]
+}
 dagboek1.title = db_title
 dagboek1.save!

--- a/projects/sport-data-valley/config/settings.yml
+++ b/projects/sport-data-valley/config/settings.yml
@@ -1,6 +1,7 @@
 # Beware! This file is public by definition
 default: &default
   default_team_name: 'sdv-team'
+  account_active_default: false
   # This settings is included only for the specs. Don't remove
   test_setting: 'test123'
   project_start_date: '2019-12-20'

--- a/projects/sport-data-valley/seeds/questionnaires/training_log.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/training_log.rb
@@ -10,7 +10,7 @@ questionnaire.key = File.basename(__FILE__)[0...-3]
 dagboek_content = [
   {
     type: :raw,
-    content: '<p class="flow-text">Feedback op de trainingssessie</p><br><img src="/sport-data-valley/training_log_header.jpg" style="width:auto" class="questionnaire-image" />',
+    content: '<p class="flow-text">Feedback op de trainingssessie</p><br><img src="/sport-data-valley/training_log_header.jpg" style="width:100%; max-width: 500px" class="questionnaire-image" />',
   },
   {
     id: :v1,

--- a/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_1_time_per_week_diary.rb
+++ b/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_1_time_per_week_diary.rb
@@ -63,7 +63,7 @@ dagboek_content = [{
 }, {
   id: :v9,
   type: :range,
-  title: ' Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
+  title: 'Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
   labels: ['niet genoeg tijd', 'te veel tijd']
 }, {
   id: :v10,

--- a/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_2_times_per_week_diary_thursday.rb
+++ b/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_2_times_per_week_diary_thursday.rb
@@ -63,7 +63,7 @@ dagboek_content = [{
 }, {
   id: :v9,
   type: :range,
-  title: ' Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
+  title: 'Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
   labels: ['niet genoeg tijd', 'te veel tijd']
 }, {
   id: :v10,

--- a/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_5_times_per_week_diary_monday.rb
+++ b/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_5_times_per_week_diary_monday.rb
@@ -19,7 +19,7 @@ dagboek_content = [{
 }, {
   id: :v2,
   type: :range,
-  title: ' Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
+  title: 'Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
   labels: ['niet genoeg tijd', 'te veel tijd']
 }, {
   id: :v3,

--- a/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_5_times_per_week_diary_thursday.rb
+++ b/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_5_times_per_week_diary_thursday.rb
@@ -63,7 +63,7 @@ dagboek_content = [{
 }, {
   id: :v9,
   type: :range,
-  title: ' Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
+  title: 'Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
   labels: ['niet genoeg tijd', 'te veel tijd']
 }, {
   id: :v10,

--- a/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_5_times_per_week_diary_tuesday_wednesday_friday.rb
+++ b/projects/u-can-act/seeds/questionnaires/pilot/pilot_student_5_times_per_week_diary_tuesday_wednesday_friday.rb
@@ -62,7 +62,7 @@ dagboek_content = [{
 }, {
   id: :v9,
   type: :range,
-  title: ' Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
+  title: 'Was dit <strong>genoeg tijd</strong> om goed te presteren op school?',
   labels: ['niet genoeg tijd', 'te veel tijd']
 }, {
   id: :v10,

--- a/spec/helpers/distribution_helper_spec.rb
+++ b/spec/helpers/distribution_helper_spec.rb
@@ -37,11 +37,11 @@ describe DistributionHelper do
         aquestion[:min] = 2.5
         aquestion[:max] = 4
         aquestion[:step] = 0.5
-        value = '3.0'
+        value = '3'
         distribution = {}
         helper.initialize_question(aquestion, value, distribution)
-        expected = { v2: { '2.5' => { '_' => 0 }, '3.0' => { '_' => 0 },
-                           '3.5' => { '_' => 0 }, '4.0' => { '_' => 0 } } }
+        expected = { v2: { '2.5' => { '_' => 0 }, '3' => { '_' => 0 },
+                           '3.5' => { '_' => 0 }, '4' => { '_' => 0 } } }
         expect(distribution).to eq expected
       end
     end
@@ -70,6 +70,26 @@ describe DistributionHelper do
         expected = { s1: { '3' => { '_' => 0 } } }
         expect(distribution).to eq expected
       end
+    end
+  end
+
+  describe 'number_to_string' do
+    it 'works with integers' do
+      expect(helper.number_to_string(15)).to eq '15'
+      expect(helper.number_to_string(-2)).to eq '-2'
+      expect(helper.number_to_string(0)).to eq '0'
+      expect(helper.number_to_string(2.0)).to eq '2'
+      expect(helper.number_to_string(2.00)).to eq '2'
+      expect(helper.number_to_string(-3.000)).to eq '-3'
+    end
+    it 'works with floats' do
+      expect(helper.number_to_string(0.5)).to eq '0.5'
+      expect(helper.number_to_string(1.5)).to eq '1.5'
+      expect(helper.number_to_string(1.50)).to eq '1.5'
+      expect(helper.number_to_string(1.05)).to eq '1.05'
+      expect(helper.number_to_string(1.050)).to eq '1.05'
+      expect(helper.number_to_string(-2.42)).to eq '-2.42'
+      expect(helper.number_to_string(-2.40)).to eq '-2.4'
     end
   end
 end

--- a/spec/jobs/recalculate_scores_job_spec.rb
+++ b/spec/jobs/recalculate_scores_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RecalculateScoresJob do
+  describe '#perform_later' do
+    it 'performs something later' do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        described_class.perform_later(1)
+      end.to have_enqueued_job(described_class)
+    end
+  end
+
+  describe 'perform' do
+    it 'calls the recalculate scores use case with the correct parameters' do
+      questionnaire = FactoryBot.create(:questionnaire)
+      expect(RecalculateScores).to receive(:run!).with(questionnaire: questionnaire)
+      described_class.perform_now(questionnaire.id)
+    end
+  end
+
+  describe 'max_attempts' do
+    it 'is two' do
+      expect(subject.max_attempts).to eq 2
+    end
+  end
+
+  describe 'reschedule_at' do
+    it 'is in one hour' do
+      time_now = Time.zone.now
+      expect(subject.reschedule_at(time_now, 1)).to be_within(1.minute)
+        .of(TimeTools.increase_by_duration(time_now, 5.minutes))
+    end
+  end
+end

--- a/spec/logic/jwt_authenticator_spec.rb
+++ b/spec/logic/jwt_authenticator_spec.rb
@@ -32,6 +32,8 @@ describe JwtAuthenticator do
       cookie = { TokenAuthenticationController::JWT_TOKEN_COOKIE => token }
       expect(CookieJar).to receive(:set_or_update_cookie)
         .with(cookies, cookie)
+      expect(CookieJar).to receive(:delete_cookie)
+        .with(cookies, TokenAuthenticationController::PERSON_ID_COOKIE)
 
       result = described_class.auth_from_cookies(cookies)
       expect(result).to eql person
@@ -65,6 +67,8 @@ describe JwtAuthenticator do
       cookie = { TokenAuthenticationController::JWT_TOKEN_COOKIE => token }
       expect(CookieJar).to receive(:set_or_update_cookie)
         .with(cookies, cookie)
+      expect(CookieJar).to receive(:delete_cookie)
+        .with(cookies, TokenAuthenticationController::PERSON_ID_COOKIE)
 
       result = described_class.auth_from_params(cookies, auth: 'valid auth')
       expect(result).to eql person

--- a/spec/logic/jwt_authenticator_spec.rb
+++ b/spec/logic/jwt_authenticator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe JwtAuthenticator do
-  describe 'auth' do
+  describe 'auth_from_cookies' do
     let(:person) { FactoryBot.create(:person, :with_auth_user) }
 
     it 'should use the auth from the cookiejar if available' do
@@ -17,16 +17,8 @@ describe JwtAuthenticator do
       expect(described_class).to receive(:store_token_in_cookie)
         .and_return(true)
 
-      result = described_class.auth(cookies, {})
+      result = described_class.auth_from_cookies(cookies)
       expect(result).to eql person
-    end
-
-    it 'should return nil if the stuff in the header is not a jwt token' do
-      cookies = double('cookies')
-      params = { auth: 'this is not a token!' }
-      expect(CookieJar).not_to receive(:read_entry) # it will call the jwt decoder instead
-      result = described_class.auth(cookies, params)
-      expect(result).to be_nil
     end
 
     it 'should store the token in a cookie' do
@@ -41,7 +33,40 @@ describe JwtAuthenticator do
       expect(CookieJar).to receive(:set_or_update_cookie)
         .with(cookies, cookie)
 
-      result = described_class.auth(cookies, {})
+      result = described_class.auth_from_cookies(cookies)
+      expect(result).to eql person
+    end
+  end
+
+  describe 'auth_from_params' do
+    let(:person) { FactoryBot.create(:person, :with_auth_user) }
+
+    it 'should not do anything with empty params' do
+      cookies = double('cookies')
+      expect(CookieJar).not_to receive(:read_entry) # it will call the jwt decoder instead
+      result = described_class.auth_from_params(cookies, {})
+      expect(result).to be_nil
+    end
+
+    it 'should return nil if the stuff in the header is not a jwt token' do
+      cookies = double('cookies')
+      params = { auth: 'this is not a token!' }
+      expect(CookieJar).not_to receive(:read_entry) # it will call the jwt decoder instead
+      result = described_class.auth_from_params(cookies, params)
+      expect(result).to be_nil
+    end
+
+    it 'should store the token in a cookie' do
+      cookies = double('cookies')
+      token = [{ 'sub' => person.auth_user.auth0_id_string }]
+      expect(CookieJar).not_to receive(:read_entry)
+      expect(JWT).to receive(:decode).and_return(token)
+
+      cookie = { TokenAuthenticationController::JWT_TOKEN_COOKIE => token }
+      expect(CookieJar).to receive(:set_or_update_cookie)
+        .with(cookies, cookie)
+
+      result = described_class.auth_from_params(cookies, auth: 'valid auth')
       expect(result).to eql person
     end
   end

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -313,6 +313,27 @@ describe Questionnaire do
     end
   end
 
+  describe 'recalculate_scores!' do
+    it 'should call the recalculate_scores job' do
+      questionnaire = FactoryBot.create(:questionnaire)
+      measurement = FactoryBot.create(:measurement, questionnaire: questionnaire)
+      old_response_content_content = { 'v1' => '25', 'v2' => '26', 's1' => '27' }
+      reponse_content = FactoryBot.create(:response_content, content: old_response_content_content)
+      response_obj = FactoryBot.create(:response, :completed, measurement: measurement)
+      response_obj.content = reponse_content.id
+      response_obj.save!
+      expect(RecalculateScoresJob).to receive(:perform_later).with(response_obj.id)
+      questionnaire.recalculate_scores!
+    end
+    it 'should do nothing when there are no completed responses' do
+      questionnaire = FactoryBot.create(:questionnaire)
+      measurement = FactoryBot.create(:measurement, questionnaire: questionnaire)
+      FactoryBot.create(:response, measurement: measurement)
+      expect(RecalculateScoresJob).not_to receive(:perform_later)
+      questionnaire.recalculate_scores!
+    end
+  end
+
   describe 'responses' do
     it 'counts all the responses that it is used for' do
       questionnaire = FactoryBot.create(:questionnaire)

--- a/spec/models/response_content_spec.rb
+++ b/spec/models/response_content_spec.rb
@@ -45,8 +45,10 @@ describe ResponseContent do
       measurement = FactoryBot.create(:measurement, questionnaire: questionnaire)
       response = FactoryBot.create(:response, measurement: measurement)
       content = { 'v1' => '23' }
-      expected = { 'v1' => '23', 's1' => '23' }
-      expect(described_class.create_with_scores!(content: content, response: response).content).to eq(expected)
+      expected = { 's1' => '23' }
+      rescontent = described_class.create_with_scores!(content: content, response: response)
+      expect(rescontent.content).to eq content
+      expect(rescontent.scores).to eq expected
     end
   end
 end

--- a/spec/tools/cookie_jar_spec.rb
+++ b/spec/tools/cookie_jar_spec.rb
@@ -27,6 +27,30 @@ describe CookieJar do
     end
   end
 
+  describe 'delete_cookie' do
+    it 'deletes a given cookie' do
+      current_cookie = {
+        response_id: '123',
+        token: 'whatever'
+      }
+      jar[described_class::COOKIE_LOCATION] = current_cookie.to_json
+      response_hash = { response_id: '123' }
+      described_class.delete_cookie(jar, :token)
+      expect(jar[described_class::COOKIE_LOCATION]).to eq response_hash.to_json
+    end
+
+    it 'does nothing with unknown key' do
+      current_cookie = {
+        response_id: '123',
+        token: 'whatever'
+      }
+      jar[described_class::COOKIE_LOCATION] = current_cookie.to_json
+      response_hash = { response_id: '123', token: 'whatever' }
+      described_class.delete_cookie(jar, :hihaho)
+      expect(jar[described_class::COOKIE_LOCATION]).to eq response_hash.to_json
+    end
+  end
+
   describe 'cookies_set?' do
     it 'returns false if no cookies are set' do
       expect(described_class).not_to be_cookies_set(jar)

--- a/spec/use_cases/calculate_scores_spec.rb
+++ b/spec/use_cases/calculate_scores_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe EnrichContent do
+describe CalculateScores do
   describe 'execute' do
     let(:content) do
       {
@@ -21,14 +21,14 @@ describe EnrichContent do
                    round_to_decimals: 1 }]
       }
     end
-    let(:enriched_content) do
+    let(:scores) do
       {
         's1' => '25.5'
       }
     end
 
     it 'should enrich the content correctly' do
-      expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+      expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
     end
 
     context 'rounding' do
@@ -39,29 +39,29 @@ describe EnrichContent do
                                     operation: :average,
                                     require_all: false }]
         content = { 'v1' => '25.323434983' }
-        enriched_content = { 's1' => '25.323434983' }
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = { 's1' => '25.323434983' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
         content = { 'v1' => '-17' }
-        enriched_content = { 's1' => '-17' }
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = { 's1' => '-17' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'should round a float to an integer if round_to_decimals is 0' do
         questionnaire[:scores][0][:round_to_decimals] = 0
-        enriched_content = { 's1' => '26' }
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = { 's1' => '26' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'should round to the number of decimals specified' do
         questionnaire[:scores][0][:round_to_decimals] = 2
         content = { 'v1' => '25.326434983' }
-        enriched_content = { 's1' => '25.33' }
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = { 's1' => '25.33' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
     end
 
     context 'missing values' do
       it 'should still continue if one of the values is missing' do
         questionnaire[:scores][0][:ids] = %i[v3 v4 v1 v2 v5]
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'should not continue if the require_all option is present' do
         questionnaire[:scores][0][:ids] = %i[v1 v2 v3]
@@ -70,7 +70,7 @@ describe EnrichContent do
       end
       it 'but it should continue if all values are present' do
         questionnaire[:scores][0][:require_all] = true
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'should not do anything if there are no values left' do
         content = {}
@@ -102,8 +102,8 @@ describe EnrichContent do
           require_all: true,
           round_to_decimals: 3
         }]
-        enriched_content = { 's1' => '2.25', 's2' => '7', 's3' => '4.625' }
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = { 's1' => '2.25', 's2' => '7', 's3' => '4.625' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'works with rounding' do
         content = { 'v1' => '0', 'v4' => '4.5', 'v5' => '8', 'v6' => '6' }
@@ -128,8 +128,8 @@ describe EnrichContent do
           require_all: true,
           round_to_decimals: 2
         }]
-        enriched_content = { 's1' => '2.25', 's2' => '7', 's3' => '4.63' }
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = { 's1' => '2.25', 's2' => '7', 's3' => '4.63' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'works with missing values' do
         content = { 'v1' => '0', 'v4' => '4.5', 'v5' => '8', 'v6' => '6' }
@@ -154,8 +154,8 @@ describe EnrichContent do
           require_all: true,
           round_to_decimals: 3
         }]
-        enriched_content = { 's1' => '2.25' }
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = { 's1' => '2.25' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'works with missing values if require_all is false' do
         content = { 'v1' => '0', 'v4' => '4.5', 'v5' => '8', 'v6' => '6' }
@@ -179,8 +179,8 @@ describe EnrichContent do
           ids: %i[s1 s2],
           operation: :average
         }]
-        enriched_content = { 's1' => '2.25', 's3' => '2.25' }
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = { 's1' => '2.25', 's3' => '2.25' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
     end
 
@@ -203,25 +203,25 @@ describe EnrichContent do
                      round_to_decimals: 1 }]
         }
       end
-      let(:enriched_content) do
+      let(:scores) do
         {
           's1' => '25.5'
         }
       end
 
       it 'should enrich the content correctly' do
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'should fail when a value cannot be converted to a numerical value' do
         content = { 'v1' => 'title2', 'v2' => 'title2' }
-        enriched_content = {}
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        scores = {}
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
       it 'should not fail when a value cannot be converted to a numerical value if require_all is not true' do
         content = { 'v1' => 'title2', 'v2' => 'title2' }
-        enriched_content = { 's1' => '26' }
+        scores = { 's1' => '26' }
         questionnaire[:scores].first[:require_all] = false
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
     end
 
@@ -243,11 +243,11 @@ describe EnrichContent do
                      round_to_decimals: 1 }]
         }
       end
-      let(:enriched_content) do
+      let(:scores) do
         { }
       end
       it 'should remove previous score definitions' do
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores
       end
     end
   end

--- a/spec/use_cases/calculate_scores_spec.rb
+++ b/spec/use_cases/calculate_scores_spec.rb
@@ -244,7 +244,7 @@ describe CalculateScores do
         }
       end
       let(:scores) do
-        { }
+        {}
       end
       it 'should remove previous score definitions' do
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq scores

--- a/spec/use_cases/enrich_content_spec.rb
+++ b/spec/use_cases/enrich_content_spec.rb
@@ -232,5 +232,33 @@ describe EnrichContent do
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
     end
+
+    context 'score recalculation' do
+      let(:content) do
+        {
+          'v1' => '25',
+          's1' => '25.5'
+        }
+      end
+      let(:questionnaire) do
+        {
+          questions: [{ id: :v1, type: :number, title: 'title1' }, { id: :v2, type: :number, title: 'title2' }],
+          scores: [{ id: :s1,
+                     label: 'average of v1 and v2',
+                     ids: %i[v1 v2],
+                     operation: :average,
+                     require_all: true,
+                     round_to_decimals: 1 }]
+        }
+      end
+      let(:enriched_content) do
+        {
+          'v1' => '25'
+        }
+      end
+      it 'should remove previous score definitions' do
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+      end
+    end
   end
 end

--- a/spec/use_cases/enrich_content_spec.rb
+++ b/spec/use_cases/enrich_content_spec.rb
@@ -189,5 +189,48 @@ describe EnrichContent do
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
     end
+
+    context 'numeric_value of options' do
+      let(:content) do
+        {
+          'v1' => 'title1',
+          'v2' => 'title2'
+        }
+      end
+      let(:questionnaire) do
+        {
+          questions: [{ id: :v1, type: :dropdown, options: [{ title: 'title1', numeric_value: 25 }] },
+                      { id: :v2, type: :radio, options: [{ title: 'title2', numeric_value: 26 }] }],
+          scores: [{ id: :s1,
+                     label: 'average of v1 and v2',
+                     ids: %i[v1 v2],
+                     operation: :average,
+                     require_all: true,
+                     round_to_decimals: 1 }]
+        }
+      end
+      let(:enriched_content) do
+        {
+          'v1' => 'title1',
+          'v2' => 'title2',
+          's1' => '25.5'
+        }
+      end
+
+      it 'should enrich the content correctly' do
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+      end
+      it 'should fail when a value cannot be converted to a numerical value' do
+        content = { 'v1' => 'title2', 'v2' => 'title2' }
+        enriched_content = { 'v1' => 'title2', 'v2' => 'title2' }
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+      end
+      it 'should not fail when a value cannot be converted to a numerical value if require_all is not true' do
+        content = { 'v1' => 'title2', 'v2' => 'title2' }
+        enriched_content = { 'v1' => 'title2', 'v2' => 'title2', 's1' => '26' }
+        questionnaire[:scores].first[:require_all] = false
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
+      end
+    end
   end
 end

--- a/spec/use_cases/enrich_content_spec.rb
+++ b/spec/use_cases/enrich_content_spec.rb
@@ -23,8 +23,6 @@ describe EnrichContent do
     end
     let(:enriched_content) do
       {
-        'v1' => '25',
-        'v2' => '26',
         's1' => '25.5'
       }
     end
@@ -41,21 +39,21 @@ describe EnrichContent do
                                     operation: :average,
                                     require_all: false }]
         content = { 'v1' => '25.323434983' }
-        enriched_content = { 'v1' => '25.323434983', 's1' => '25.323434983' }
+        enriched_content = { 's1' => '25.323434983' }
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
         content = { 'v1' => '-17' }
-        enriched_content = { 'v1' => '-17', 's1' => '-17' }
+        enriched_content = { 's1' => '-17' }
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
       it 'should round a float to an integer if round_to_decimals is 0' do
         questionnaire[:scores][0][:round_to_decimals] = 0
-        enriched_content = { 'v1' => '25', 'v2' => '26', 's1' => '26' }
+        enriched_content = { 's1' => '26' }
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
       it 'should round to the number of decimals specified' do
         questionnaire[:scores][0][:round_to_decimals] = 2
         content = { 'v1' => '25.326434983' }
-        enriched_content = { 'v1' => '25.326434983', 's1' => '25.33' }
+        enriched_content = { 's1' => '25.33' }
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
     end
@@ -68,7 +66,7 @@ describe EnrichContent do
       it 'should not continue if the require_all option is present' do
         questionnaire[:scores][0][:ids] = %i[v1 v2 v3]
         questionnaire[:scores][0][:require_all] = true
-        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq content
+        expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq({})
       end
       it 'but it should continue if all values are present' do
         questionnaire[:scores][0][:require_all] = true
@@ -104,8 +102,7 @@ describe EnrichContent do
           require_all: true,
           round_to_decimals: 3
         }]
-        enriched_content = { 'v1' => '0', 'v4' => '4.5', 'v5' => '8', 'v6' => '6',
-                             's1' => '2.25', 's2' => '7', 's3' => '4.625' }
+        enriched_content = { 's1' => '2.25', 's2' => '7', 's3' => '4.625' }
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
       it 'works with rounding' do
@@ -131,8 +128,7 @@ describe EnrichContent do
           require_all: true,
           round_to_decimals: 2
         }]
-        enriched_content = { 'v1' => '0', 'v4' => '4.5', 'v5' => '8', 'v6' => '6',
-                             's1' => '2.25', 's2' => '7', 's3' => '4.63' }
+        enriched_content = { 's1' => '2.25', 's2' => '7', 's3' => '4.63' }
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
       it 'works with missing values' do
@@ -158,8 +154,7 @@ describe EnrichContent do
           require_all: true,
           round_to_decimals: 3
         }]
-        enriched_content = { 'v1' => '0', 'v4' => '4.5', 'v5' => '8', 'v6' => '6',
-                             's1' => '2.25' }
+        enriched_content = { 's1' => '2.25' }
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
       it 'works with missing values if require_all is false' do
@@ -184,8 +179,7 @@ describe EnrichContent do
           ids: %i[s1 s2],
           operation: :average
         }]
-        enriched_content = { 'v1' => '0', 'v4' => '4.5', 'v5' => '8', 'v6' => '6',
-                             's1' => '2.25', 's3' => '2.25' }
+        enriched_content = { 's1' => '2.25', 's3' => '2.25' }
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
     end
@@ -211,8 +205,6 @@ describe EnrichContent do
       end
       let(:enriched_content) do
         {
-          'v1' => 'title1',
-          'v2' => 'title2',
           's1' => '25.5'
         }
       end
@@ -222,12 +214,12 @@ describe EnrichContent do
       end
       it 'should fail when a value cannot be converted to a numerical value' do
         content = { 'v1' => 'title2', 'v2' => 'title2' }
-        enriched_content = { 'v1' => 'title2', 'v2' => 'title2' }
+        enriched_content = {}
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
       it 'should not fail when a value cannot be converted to a numerical value if require_all is not true' do
         content = { 'v1' => 'title2', 'v2' => 'title2' }
-        enriched_content = { 'v1' => 'title2', 'v2' => 'title2', 's1' => '26' }
+        enriched_content = { 's1' => '26' }
         questionnaire[:scores].first[:require_all] = false
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content
       end
@@ -252,9 +244,7 @@ describe EnrichContent do
         }
       end
       let(:enriched_content) do
-        {
-          'v1' => '25'
-        }
+        { }
       end
       it 'should remove previous score definitions' do
         expect(described_class.run!(content: content, questionnaire: questionnaire)).to eq enriched_content

--- a/spec/use_cases/recalculate_scores_spec.rb
+++ b/spec/use_cases/recalculate_scores_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RecalculateScores do
+  describe 'execute' do
+    let!(:questionnaire) { FactoryBot.create(:questionnaire) }
+
+    it 'should store the correct results' do
+      questionnaire_content = {
+        questions: [{ id: :v1, type: :number, title: 'title1' }, { id: :v2, type: :number, title: 'title2' }],
+        scores: [{ id: :s1,
+                   label: 'average of v1 and v2',
+                   ids: %i[v1 v2],
+                   operation: :average,
+                   require_all: false,
+                   round_to_decimals: 1 }]
+      }
+      questionnaire = FactoryBot.create(:questionnaire, content: questionnaire_content)
+      measurement = FactoryBot.create(:measurement, questionnaire: questionnaire)
+      old_response_content_content = { 'v1' => '25', 'v2' => '26', 's1' => '27' }
+      reponse_content = FactoryBot.create(:response_content, content: old_response_content_content)
+      response_obj = FactoryBot.create(:response, :completed, measurement: measurement)
+      response_obj.content = reponse_content.id
+      response_obj.save!
+      expect(CalculateDistributionJob).to receive(:perform_later).with(response_obj.id)
+      described_class.run!(questionnaire: questionnaire)
+      new_response_content_content = { 'v1' => '25', 'v2' => '26', 's1' => '25.5' }
+      response_obj.reload
+      expect(response_obj.values).to eq(new_response_content_content)
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,8 +1013,8 @@
 
 "@rails/webpacker@git+https://github.com/rails/webpacker.git":
   version "4.2.2"
-  uid "0b550a0ed66f2c01baa5f05f1126abada47a6c6f"
-  resolved "git+https://github.com/rails/webpacker.git#0b550a0ed66f2c01baa5f05f1126abada47a6c6f"
+  uid "3eecc5c0596a276eb36cc84bb30829a584b6b1c0"
+  resolved "git+https://github.com/rails/webpacker.git#3eecc5c0596a276eb36cc84bb30829a584b6b1c0"
   dependencies:
     "@babel/core" "^7.7.2"
     "@babel/plugin-proposal-class-properties" "^7.7.0"
@@ -9373,9 +9373,9 @@ webpack-assets-manifest@^3.1.1:
     webpack-sources "^1.0.0"
 
 webpack-cli@^3.3.10, webpack-cli@^3.3.7:
-  version "3.3.10"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.10.tgz#17b279267e9b4fb549023fae170da8e6e766da13"
-  integrity sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.11.tgz#3bf21889bf597b5d82c38f215135a411edfdc631"
+  integrity sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==
   dependencies:
     chalk "2.4.2"
     cross-spawn "6.0.5"
@@ -9456,9 +9456,9 @@ webpack-sources@^1.0.0, webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-
     source-map "~0.6.1"
 
 webpack@^4.39.2, webpack@^4.41.3:
-  version "4.41.5"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.5.tgz#3210f1886bce5310e62bb97204d18c263341b77c"
-  integrity sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==
+  version "4.41.6"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.6.tgz#12f2f804bf6542ef166755050d4afbc8f66ba7e1"
+  integrity sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"


### PR DESCRIPTION
- [x] Add support for a `numeric_value` property for the options of questions of type likert, radio, and dropdown, used in the score calculations.
- [x] Made the range slider in questionnaires easier to click by changing the margin to padding. Now you can click anywhere on the slider and the scrollthumb will move there. (This was possible before, but it was really hard to do as the slider was only 2(?) pixels tall. Now, it's 30 pixels taller.)
- [x] Allow html formatting in dropdown displayed labels (the HTML value is still raw and unevaluated).
- [x] Changed the ordering of authentication mechanisms in application_helper.rb, so that a token given as (`token` or `auth`) params to a URL is preferred (=overrides) one that is stored in a cookie.
- [x] Added a job for recalculating questionnaire scores. You would use this, e.g., when the score definition of a questionnaire has changed. Score recalculation for a questionnaire is not done automatically, it needs to be triggered from the console, using `Questionnaire.find_by(key: 'myquestionnairekey').recalculate_scores!`. Recalculating the scores for a questionnaire also triggers recalculation for its distribution statistics.
- [x] Made the redusmutex lock wait a little bit longer (5 seconds) before giving up, as I was getting some timeout errors in the IKIA front-end application.
- [x] Fixed the bug on the SDV platform that all accounts were automatically signed up for questionnaires as soon as they navigated to the profile page. This relies on a `account_active_default` organization setting, which specifies the value that accounts created through the `CreateAnonymousUser` use case should use for the `account_active` setting of their associated person. The default is `true`, but for the sport-data-valley organization, the setting is overridden with `false`, so that not everyone from SDV is signed up for questionnaires by default.
- [x] Fixed the score calculation to better handle values that do not have a numerical reprsentation. I.e., previously, if a value was a word or a sentence, rather than a numerical value, the score calculation would call `.to_f` on this string which would return 0.0 and use that value. Now, the score calculation will try to detect if the value is a number or not, and if it is not a number, it will treat it as if the value were missing, and in case `require_all` is set to `true` for a score, this score will not be added to the result. This was added because with the addition of the `numeric_value` property to options, we needed to handle the case in which someone tried to calculate a score of an option which had no `numeric_value` property, which will now be treated as missing.
- [x] If a score fails to calculate, it is now removed from the response content if it was present there. This can only occur in the case of score recalculation, where a score was previously defined, calculated, and added to the response content. If then later, the score definition was changed (perhaps `require_all: true` was added), and the score no longer results in a value, the existing score with that name is removed from the response content. This is so that there are never different versions of score calculations for one score present. Note that any scores that were previously calculated but were removed in an updated score configuration for a questionnaire are not removed from the response content (as we don't know what their IDs are). This however, does not have negative effects: anything that is in the response content that is not explicitly defined in the questionnaire definition (e.g, *_timing keys) can be present in the response content but are not used.
- [x] The `require_all` presence check now also checks if a value is nil or not. Previously, we only checked if the response content hash had a given key, but if it had this key, and the associated value was nil, then nil.to_f would render 0.0 and the key would be seen as present. Now, blank? values are treated as missing.
- [x] Removed some redundant spacing from IKIA questionnaire definitions.
- [x] Added score definitions for some IKIA questionnaires.
- [x] Fix appsignal error when filling out a training log with a .5 on the satisfaction scale.
