### PR TITLE
Forgery robustness

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,12 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: false
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 # Default is 5
 Metrics/ParameterLists:
   Max: 6

--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -16,6 +16,7 @@ class QuestionnaireController < ApplicationController
   before_action :check_informed_consent, only: [:show]
   before_action :set_questionnaire_content, only: [:show]
   before_action :set_create_response, only: %i[create create_informed_consent]
+  before_action :check_opened_at, only: [:create]
   before_action :check_content_empty, only: [:create]
   before_action :check_content_hash, only: [:create]
   before_action :check_interactive_content, only: %i[interactive_render]
@@ -217,6 +218,13 @@ class QuestionnaireController < ApplicationController
     return if quest_content.present? && (quest_content.keys - [Response::CSRF_FAILED]).present?
 
     render(status: :bad_request, html: 'Cannot store blank questionnaire responses', layout: 'application')
+  end
+
+  def check_opened_at
+    return if @response.opened_at.present?
+
+    render(status: :bad_request, html: 'Cannot accept answers for an unopened response',
+           layout: 'application')
   end
 
   def check_informed_consent

--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -16,6 +16,7 @@ class QuestionnaireController < ApplicationController
   before_action :check_informed_consent, only: [:show]
   before_action :set_questionnaire_content, only: [:show]
   before_action :set_create_response, only: %i[create create_informed_consent]
+  before_action :check_content_empty, only: [:create]
   before_action :check_content_hash, only: [:create]
   before_action :check_interactive_content, only: %i[interactive_render]
   before_action :set_interactive_content, only: %i[interactive_render]
@@ -209,6 +210,13 @@ class QuestionnaireController < ApplicationController
              layout: 'application')
       break
     end
+  end
+
+  def check_content_empty
+    quest_content = questionnaire_content
+    return if quest_content.present? && (quest_content.keys - [Response::CSRF_FAILED]).present?
+
+    render(status: :bad_request, html: 'Cannot store blank questionnaire responses', layout: 'application')
   end
 
   def check_informed_consent

--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -325,7 +325,7 @@ class QuestionnaireController < ApplicationController
     return if valid_request_origin? && any_authenticity_token_valid?
 
     record_warning_in_rails_logger
-    params['content']['csrf_failed'] = 'true' if params['content'].present?
+    params['content'][Response::CSRF_FAILED] = 'true' if params['content'].present?
   end
 
   def record_warning_in_rails_logger

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -82,14 +82,17 @@ module DistributionHelper
   end
 
   def process_response_ids(response_ids)
+    added_count = 0
     ResponseContent.where(:id.in => response_ids).pluck(:content, :scores).each do |content, scores|
-      next if content.nil? # Can theoretically happen
+      next if content.blank? || content[Response::CSRF_FAILED].present? # Don't calculate statistics for bogus responses
 
+      added_count += 1
       all_content = scores.present? ? content.merge(scores) : content
       @usable_questions.each do |question|
         add_to_distribution(question, all_content, @distribution)
       end
     end
+    added_count
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/use_cases/calculate_distribution.rb
+++ b/app/use_cases/calculate_distribution.rb
@@ -9,17 +9,19 @@ class CalculateDistribution < ActiveInteraction::Base
   #
   # @param questionnaire [Questionnaire] the current questionnaire
   def execute
-    @distribution = { 'total' => questionnaire.responses.completed.count }
+    @distribution = { 'total' => 0 }
     @usable_questions = usable_questions
 
     offset = 0
+    total_count = 0
     loop do
       response_ids = questionnaire.responses.completed.limit(BATCH_SIZE).offset(offset).pluck(:content)
       break if response_ids.blank?
 
-      process_response_ids(response_ids)
+      total_count += process_response_ids(response_ids)
       offset += BATCH_SIZE
     end
+    @distribution['total'] = total_count
     RedisService.set("distribution_#{questionnaire.key}", @distribution.to_json)
   end
 end

--- a/app/use_cases/recalculate_scores.rb
+++ b/app/use_cases/recalculate_scores.rb
@@ -24,7 +24,9 @@ class RecalculateScores < ActiveInteraction::Base
 
   def recalculate_response_ids(response_ids)
     ResponseContent.where(:id.in => response_ids).pluck(:content, :id).each do |content, rcid|
-      next if content.nil? # Can theoretically happen
+      # Note that we don't check for csrf_failed here (on purpose)
+      # It doesn't hurt to calculate scores for csrf_failed responses.
+      next if content.blank? # Can theoretically happen.
 
       scores = CalculateScores.run!(content: content, questionnaire: @questionnaire_content)
       ResponseContent.find(rcid)&.update!(scores: scores)

--- a/app/use_cases/update_distribution.rb
+++ b/app/use_cases/update_distribution.rb
@@ -15,9 +15,8 @@ class UpdateDistribution < ActiveInteraction::Base
       CalculateDistribution.run!(questionnaire: questionnaire)
       return
     end
-    @distribution['total'] += 1
     @usable_questions = usable_questions
-    process_response_ids([response.content])
+    @distribution['total'] += process_response_ids([response.content])
     RedisService.set("distribution_#{questionnaire.key}", @distribution.to_json)
   end
 end

--- a/spec/controllers/questionnaire_controller_spec.rb
+++ b/spec/controllers/questionnaire_controller_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe QuestionnaireController, type: :controller do
           responseobj.reload
           expect(responseobj.completed_at).to be_within(1.minute).of(Time.zone.now)
           expect(responseobj.content).not_to be_nil
-          expect(responseobj.values).to eq('v1' => 'true', 'csrf_failed' => 'true')
+          expect(responseobj.values).to eq('v1' => 'true', Response::CSRF_FAILED => 'true')
         end
       end
     end

--- a/spec/factories/questionnaires.rb
+++ b/spec/factories/questionnaires.rb
@@ -163,7 +163,10 @@ FactoryBot.define do
     trait :minimal do
       content do
         {
-          questions: [{ type: :raw, content: '<p>Hoihoihoi</p>' }],
+          questions: [
+            { type: :raw, content: '<p>Hoihoihoi</p>' },
+            { type: :checkbox, id: :v1, title: 'Tick this box?', options: %w[Yes No] }
+          ],
           scores: []
         }
       end

--- a/spec/features/questionnaires_spec.rb
+++ b/spec/features/questionnaires_spec.rb
@@ -849,6 +849,7 @@ describe 'GET and POST /', type: :feature, js: true do
       visit responseobj.invitation_set.invitation_url(invitation_token.token_plain, false)
       expect(page).to have_content('vragenlijst-dagboekstudie-studenten')
       # v1
+      page.check('Nee', allow_label_click: true)
       page.click_on 'Opslaan'
       expect(page).to have_content('Bedankt voor het invullen van de vragenlijst!')
       expect(page).not_to have_content('Je hebt je uitgeschreven voor het '\
@@ -2538,6 +2539,7 @@ describe 'GET and POST /', type: :feature, js: true do
       expect(page).not_to have_current_path(mentor_overview_index_path)
       expect(page).to have_content('vragenlijst-dagboekstudie-studenten')
       expect(page).to have_content('Hoihoihoi')
+      page.check('Yes', allow_label_click: true)
       page.click_on 'Opslaan'
       expect(page).to have_content(person_header)
     end

--- a/spec/use_cases/calculate_distribution_spec.rb
+++ b/spec/use_cases/calculate_distribution_spec.rb
@@ -22,6 +22,17 @@ describe CalculateDistribution do
       response_obj = FactoryBot.create(:response, :completed, measurement: measurement)
       response_obj.content = reponse_content.id
       response_obj.save!
+
+      # it should ignore csrf_failed responses
+      reponse_content2 = FactoryBot.create(:response_content, content: {
+                                             'v2_pizza' => 'true',
+                                             'v3' => '70',
+                                             'v4' => '2019-02-06',
+                                             'csrf_failed' => 'true'
+                                           })
+      response_obj2 = FactoryBot.create(:response, :completed, measurement: measurement)
+      response_obj2.content = reponse_content2.id
+      response_obj2.save!
       expected = {
         'total' => 1,
         'v3' => {

--- a/spec/use_cases/update_distribution_spec.rb
+++ b/spec/use_cases/update_distribution_spec.rb
@@ -4,27 +4,35 @@ require 'rails_helper'
 
 describe UpdateDistribution do
   describe 'execute' do
-    let!(:questionnaire) { FactoryBot.create(:questionnaire) }
-
     it 'should store the correct results' do
       reponse_content = FactoryBot.create(:response_content, content: { 'v3' => '68' })
       responseobj = FactoryBot.create(:response)
       responseobj.content = reponse_content.id
       responseobj.save!
-      expected = { 'total' => 1, 'v3' => {} }
-      (0..100).each do |val|
-        expected['v3'][val.to_s] = { '_' => 0 }
-      end
-      initial_distribution = expected.deep_dup
-      expected['v3']['68']['_'] = 1
+      initial_distribution = { 'total' => 1 }
+      expected = initial_distribution.deep_dup
+      expected['v3'] = { '_min' => 0, '_max' => 100, '_step' => 1, '68' => { '_' => 1 } }
       expected['total'] = 2
-      expect(initial_distribution['v3']['68']['_']).to eq(0)
       expect(RedisService).to(receive(:get).with(
         "distribution_#{responseobj.measurement.questionnaire.key}"
       ).and_return(initial_distribution.to_json))
       expect(RedisService).to receive(:set).with("distribution_#{responseobj.measurement.questionnaire.key}",
                                                  expected.to_json)
-      expect(described_class.run!(questionnaire: responseobj.measurement.questionnaire, response: responseobj))
+      described_class.run!(questionnaire: responseobj.measurement.questionnaire, response: responseobj)
+    end
+
+    it 'should ignore responses with csrf_failed' do
+      reponse_content = FactoryBot.create(:response_content, content: { 'v3' => '68', Response::CSRF_FAILED => 'true' })
+      responseobj = FactoryBot.create(:response)
+      responseobj.content = reponse_content.id
+      responseobj.save!
+      initial_distribution = { 'total' => 1 }
+      expect(RedisService).to(receive(:get).with(
+        "distribution_#{responseobj.measurement.questionnaire.key}"
+      ).and_return(initial_distribution.to_json))
+      expect(RedisService).to receive(:set).with("distribution_#{responseobj.measurement.questionnaire.key}",
+                                                 initial_distribution.to_json)
+      described_class.run!(questionnaire: responseobj.measurement.questionnaire, response: responseobj)
     end
   end
 end


### PR DESCRIPTION
1. als csrf_failed -> roep niet de push subscriptions aan
1a. if csrf_failed -> don't calculate statistics for this response
1b. if csrf_failed -> we do calculate scores for this response
2. als values een lege hash is, ignore dan het request om die response aan te maken
3. ignore het request om een response te completen als de opened_at null is

The above controller checks exclude API calls to create questionnaire responses. They are only in effect for the regular questionnaires_controller (where were render a page showing the questionnaire for users).