### PR TITLE
Invitation link fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'pry-rails'
 
 gem 'dotenv-rails'
 
-gem 'coveralls', require: false
+gem 'coveralls_reborn', require: false
 
 # Delayed job for delayed calculation
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,12 +126,11 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
-    coveralls (0.7.1)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
+    coveralls_reborn (0.20.0)
+      simplecov (>= 0.18.1, < 0.22.0)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     crass (1.0.6)
     daemons (1.3.1)
     database_cleaner (1.8.5)
@@ -478,7 +477,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.2)
-    tins (1.25.0)
+    tins (1.28.0)
       sync
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
@@ -533,7 +532,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   coffee-rails
-  coveralls
+  coveralls_reborn
   daemons
   database_cleaner
   database_cleaner-active_record

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ logo:
 ```
 The settings in `settings.yml` should be sectioned under `development`, `production`, `test`, and `staging`. See the relevant files in this repository for examples.
 
+### Feature toggles
+
+The `settings.yml` file has a `feature_toggles` section with the following entries:
+
+- `allow_identifier_export` (defaults to `false`): By default, the Person export available from the admin dashboard only exports the properties `gender` and `first_name` (along with role, title, team name and organization name) for a Person. Enabling this feature allows for exporting an additional Identifiers file with email and mobile phone numbers, tied to a person id.
+- `allow_distribution_export` (defaults to `false`): Enabling this feature allows for exporting the distributions (i.e., how often people gave a certain answer, for all possible answers, for all questionnaires) for any valid JWT token (belonging to a person) through the JWT API. This is used e.g., for the IKIA project to display distributions in graphs alongside the scores of the user.
+- `realtime_distributions` (defaults to `true`): Whether or not the distributions (see above) should be kept up-to-date in real time (i.e., updated after every filled out response). This should typically be set to true, because it introduces very little overhead. There is also a nightly job that calculates distributions (doing the same thing, but then with a day delay), so if rather have that distributions update once per day, you can set this to `false`.
+- `google_analytics` (defaults to `true`): Whether or not Google Analytics should be enabled for the site. Currently, analytics for all deploys of this repo are reported under the `UA-100060757-1` Compsy property. This should really be separate per deploy, but right now it isn't.
+- `allow_response_uuid_login` (defaults to `false`): Setting this feature toggle to true allows users to use a questionnaire uuid link to log in. This may or may not help with filling out questionnaires under Edge/Outlook where for some reason redirects are followed but cookies are not being set correctly. Since there are many UUIDs, the risk of a person randomly guessing one is low. This risk is further lowered because only UUIDs for responses that have been opened and are not yet completed are valid. And even when someone does guess a UUID, there is no information leaked: they can fill out a questionnaire but that's it.
+
 ### Development configuration
 In order to run the Capybara specs of the VSV project, you need to install the chrome headless browser. In MacOS you can do this using Homebrew:
 ```

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -221,7 +221,7 @@ body {
 
 .logo-image {
   width: 20%;
-  margin: auto;
+  margin: 20px auto auto;
   display: block;
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,11 +25,6 @@ class ApplicationController < ActionController::Base
     Rails.logger.info msg
   end
 
-  def store_verification_cookie
-    cookie = { TEST_COOKIE => TEST_COOKIE_ENTRY }
-    CookieJar.set_or_update_cookie(cookies.signed, cookie)
-  end
-
   def permit_recursive_params(params)
     # TODO: remove this function in rails 5.1 (which is already out, but not supported by delayed_job_active_record)
     return [] if params.blank?

--- a/app/controllers/token_authentication_controller.rb
+++ b/app/controllers/token_authentication_controller.rb
@@ -41,14 +41,6 @@ class TokenAuthenticationController < ApplicationController
     store_person_cookie(identifier_param)
   end
 
-  def store_person_cookie(identifier)
-    cookie = { PERSON_ID_COOKIE => identifier }
-    CookieJar.set_or_update_cookie(cookies.signed, cookie)
-    # Remove the JWTAuthenticator cookie if set, so we log out any other sessions on this browser.
-    CookieJar.delete_cookie(cookies.signed, JWT_TOKEN_COOKIE)
-    store_verification_cookie
-  end
-
   def identifier_param
     identifier = questionnaire_params[:q]
     identifier[0...Person::IDENTIFIER_LENGTH] if identifier

--- a/app/controllers/token_authentication_controller.rb
+++ b/app/controllers/token_authentication_controller.rb
@@ -10,29 +10,30 @@ class TokenAuthenticationController < ApplicationController
   PERSON_ID_COOKIE = :person_id
 
   def show
-    current_person = @all_responses.first.person
+    current_person = @attached_responses.first.person
     only_non_completed_responses = InvitationToken.find_attached_responses(questionnaire_params[:q], true)
     if current_person.mentor? &&
-       (!@all_responses.first.protocol_subscription.for_myself? || only_non_completed_responses.blank?)
+       (!@attached_responses.first.protocol_subscription.for_myself? || only_non_completed_responses.blank?)
       # If we are a mentor, and the first response was already filled out or there is no response to fill out,
       # redirect to the mentor dashboard and/or follow the logic of the next page finder.
       redirect_to questionnaire_index_path
-    elsif only_non_completed_responses.blank?
+    elsif only_non_completed_responses.present?
       # If we are not a mentor or the prot sub is for ourselves, then we want to redirect to the response,
       # but only if it is not yet completed. Otherwise give an error.
-      render(status: :not_found, html: 'Deze link is niet (meer) geldig.', layout: 'application')
-    else
       # If we have an open response to redirect to, give priority to the response from
       # the set we actually clicked on (i.e., the first in the invitation set that is still open).
       redirect_to preference_questionnaire_index_path(uuid: only_non_completed_responses.first.uuid)
+    else
+      # If there are no responses to be filled out, and we are not a mentor, render an error.
+      render(status: :not_found, html: 'Deze link is niet (meer) geldig.', layout: 'application')
     end
   end
 
   private
 
   def set_all_responses
-    @all_responses = InvitationToken.find_attached_responses(questionnaire_params[:q], false)
-    return if @all_responses.present?
+    @attached_responses = InvitationToken.find_attached_responses(questionnaire_params[:q], false)
+    return if @attached_responses.present?
 
     render(status: :not_found, html: 'Deze link is niet (meer) geldig.', layout: 'application')
   end

--- a/app/controllers/token_authentication_controller.rb
+++ b/app/controllers/token_authentication_controller.rb
@@ -3,7 +3,8 @@
 class TokenAuthenticationController < ApplicationController
   before_action :check_params
   before_action :check_invitation_token
-  before_action :set_all_responses
+  before_action :set_attached_responses
+  before_action :set_response_to_redirect_to
 
   RESPONSE_ID_COOKIE = :response_id
   JWT_TOKEN_COOKIE = :jwt_token
@@ -11,31 +12,49 @@ class TokenAuthenticationController < ApplicationController
 
   def show
     current_person = @attached_responses.first.person
-    only_non_completed_responses = InvitationToken.find_attached_responses(questionnaire_params[:q], true)
-    if current_person.mentor? &&
-       (!@attached_responses.first.protocol_subscription.for_myself? || only_non_completed_responses.blank?)
-      # If we are a mentor, and the first response was already filled out or there is no response to fill out,
-      # redirect to the mentor dashboard and/or follow the logic of the next page finder.
+    if @response_to_redirect_to.blank?
+      # If all responses for this invitation set were filled out,
+      if current_person.mentor?
+        # then a mentor can still use the link
+        # from their invitation to view the mentor dashboard. Note that the link is only valid as long
+        # as the InvitationToken is valid (and expired Invitation tokens by default expire after 7 days).
+        # So this guarantees that any mentor can use any link sent to them for 7 days to get to their
+        # mentor dashboard, even if they filled out all responses.
+        redirect_to questionnaire_index_path
+      else
+        # A regular user however has no dashboard to go to, so if there are no more responses to fill out,
+        # their invitation link will render a 404 error.
+        render(status: :not_found, html: 'Deze link is niet (meer) geldig.', layout: 'application')
+      end
+      return
+    end
+    # We know now that we have at least one response to fill out. We prefer to redirect to the first one
+    # of this set (note that these responses are ordered by the {Response#priority_sorting_metric}).
+    # If we are a mentor and the first response to be filled out is for a student, then redirect to the
+    # mentor dashboard instead.
+    if current_person.mentor? && !@response_to_redirect_to.protocol_subscription.for_myself?
       redirect_to questionnaire_index_path
-    elsif only_non_completed_responses.present?
-      # If we are not a mentor or the prot sub is for ourselves, then we want to redirect to the response,
-      # but only if it is not yet completed. Otherwise give an error.
-      # If we have an open response to redirect to, give priority to the response from
-      # the set we actually clicked on (i.e., the first in the invitation set that is still open).
-      redirect_to preference_questionnaire_index_path(uuid: only_non_completed_responses.first.uuid)
     else
-      # If there are no responses to be filled out, and we are not a mentor, render an error.
-      render(status: :not_found, html: 'Deze link is niet (meer) geldig.', layout: 'application')
+      # If we are not a mentor or the response to be filled out is for ourselves,
+      # redirect to the response.
+      redirect_to preference_questionnaire_index_path(uuid: @response_to_redirect_to.uuid)
     end
   end
 
   private
 
-  def set_all_responses
+  def set_attached_responses
     @attached_responses = InvitationToken.find_attached_responses(questionnaire_params[:q], false)
     return if @attached_responses.present?
 
     render(status: :not_found, html: 'Deze link is niet (meer) geldig.', layout: 'application')
+  end
+
+  def set_response_to_redirect_to
+    @response_to_redirect_to = InvitationToken.find_attached_responses(questionnaire_params[:q], true).first
+
+    # I think if you return false or nil from a before_action, it stops the rendering?
+    true
   end
 
   def check_invitation_token

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -170,12 +170,14 @@ module ApplicationHelper
     return nil unless Rails.application.config.settings.feature_toggles.allow_response_uuid_login
 
     # Works on both the questionnaire and the questionnaire/preference urls
+    # uuid_match[1] is the uuid part, because the (?:) prevents the preference part
+    # from introducing a backref.
     uuid_match = %r{\A/questionnaire/(?:preference/)?([a-z0-9-]+)/?\z}.match(request&.path)
     return nil unless uuid_match.present?
 
     # The response must be opened and cannot be completed already
     # (this is so that once a response has been completed, that link cannot
-    #  be used to log in for that same user again)
+    # be used to log in for that same user again)
     response = Response.opened.find_by(uuid: uuid_match[1])
     return nil unless response.present?
 

--- a/app/models/invitation_token.rb
+++ b/app/models/invitation_token.rb
@@ -51,7 +51,7 @@ class InvitationToken < ApplicationRecord
   end
 
   def self.find_attached_responses_split(identifier, token)
-    find_invitation_token(identifier, token)&.invitation_set&.responses&.sort_by(&:priority_sorting_metric)
+    find_invitation_token(identifier, token)&.invitation_set&.responses&.opened&.sort_by(&:priority_sorting_metric)
   end
 
   def self.find_invitation_token(identifier, token)

--- a/app/models/invitation_token.rb
+++ b/app/models/invitation_token.rb
@@ -45,13 +45,15 @@ class InvitationToken < ApplicationRecord
     [identifier, token]
   end
 
-  def self.find_attached_responses(full_token)
+  def self.find_attached_responses(full_token, exclude_completed = false)
     identifier, token = InvitationToken.split_token(full_token)
-    InvitationToken.find_attached_responses_split(identifier, token)
+    InvitationToken.find_attached_responses_split(identifier, token, exclude_completed)
   end
 
-  def self.find_attached_responses_split(identifier, token)
-    find_invitation_token(identifier, token)&.invitation_set&.responses&.opened&.sort_by(&:priority_sorting_metric)
+  def self.find_attached_responses_split(identifier, token, exclude_completed)
+    responses = find_invitation_token(identifier, token)&.invitation_set&.responses
+    responses = responses&.opened if exclude_completed
+    responses&.sort_by(&:priority_sorting_metric)
   end
 
   def self.find_invitation_token(identifier, token)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -104,6 +104,7 @@ class Person < ApplicationRecord
   # and ascending open_from second. This is because we call .first on this method to determine which is the next
   # response that should be shown to the user.
   def my_open_responses(for_myself = true)
+    active_subscriptions = nil
     active_subscriptions = protocol_subscriptions.active if for_myself.blank?
     active_subscriptions ||= my_protocols(for_myself)
     active_subscriptions.map { |prot| prot.responses.opened_and_not_expired }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,7 @@ default: &default
     allow_distribution_export: false
     realtime_distributions: true
     google_analytics: true
+    allow_response_uuid_login: false
   distribution_export_min_responses: 200
   logo:
     favicon: 'favicon.ico'

--- a/projects/u-can-feel/config/settings.yml
+++ b/projects/u-can-feel/config/settings.yml
@@ -9,6 +9,7 @@ default: &default
   project_end_date: '2021-09-01'
   feature_toggles:
     google_analytics: false
+    allow_response_uuid_login: true
   logo:
     mentor_logo: 'rug_logo.png'
     student_logo: 'rug_logo.png'

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -96,6 +96,172 @@
         }
       }
     },
+    "/basic_auth_api/protocol_subscriptions/{id}": {
+      "delete": {
+        "summary": "Cancels a protocol subscription",
+        "tags": [
+          "ProtocolSubscription"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "BasicAuth": {
+            }
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "external_identifier",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "external_identifier": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "cancels a protocol subscription"
+          },
+          "401": {
+            "description": "not authenticated"
+          }
+        }
+      }
+    },
+    "/basic_auth_api/protocol_subscriptions/delegated_protocol_subscriptions": {
+      "get": {
+        "summary": "Lists all my students their protocolsubscriptions",
+        "tags": [
+          "ProtocolSubscription"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "BasicAuth": {
+            }
+          }
+        ],
+        "parameters": [
+          {
+            "name": "external_identifier",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "all delegated protocol subscriptions returned",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "person_type": {
+                    "type": "string"
+                  },
+                  "protocol_completion": {
+                    "type": "array"
+                  },
+                  "earned_euros": {
+                    "type": "number"
+                  },
+                  "max_still_awardable_euros": {
+                    "type": "number"
+                  },
+                  "euro_delta": {
+                    "type": "number"
+                  },
+                  "current_multiplier": {
+                    "type": "number"
+                  },
+                  "max_streak": {
+                    "type": "null"
+                  },
+                  "initial_multiplier": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "questionnaires": {
+                    "type": "array"
+                  },
+                  "first_name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authenticated"
+          }
+        }
+      }
+    },
+    "/basic_auth_api/protocol_subscriptions/destroy_delegated_protocol_subscriptions": {
+      "delete": {
+        "summary": "Cancels all protocol subscriptions with a certain external identifier for a user",
+        "tags": [
+          "ProtocolSubscription"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "BasicAuth": {
+            }
+          }
+        ],
+        "parameters": [
+          {
+            "name": "query",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "auth0_id_string": {
+                  "type": "string"
+                },
+                "external_identifier": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "cancels protocol subscriptions"
+          },
+          "422": {
+            "description": "external identifier not given"
+          },
+          "404": {
+            "description": "person not found"
+          },
+          "401": {
+            "description": "not authenticated"
+          }
+        }
+      }
+    },
     "/basic_auth_api/questionnaires": {
       "post": {
         "summary": "Creates a new questionnaire",
@@ -369,6 +535,9 @@
                 },
                 "email": {
                   "type": "string"
+                },
+                "timestamp": {
+                  "type": "string"
                 }
               }
             }
@@ -382,7 +551,7 @@
         ],
         "responses": {
           "200": {
-            "description": "updates the current user",
+            "description": "updates the current user if later timestamp is given",
             "schema": {
               "type": "object",
               "properties": {
@@ -399,6 +568,35 @@
                   "type": "string"
                 },
                 "mobile_phone": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "does not update the current user if older timestamp is given",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "first_name": {
+                  "type": "string"
+                },
+                "last_name": {
+                  "type": "string"
+                },
+                "gender": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "mobile_phone": {
+                  "type": "string"
+                },
+                "timestamp": {
                   "type": "string"
                 }
               }
@@ -577,63 +775,15 @@
                   },
                   "initial_multiplier": {
                     "type": "number"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "not authenticated"
-          }
-        }
-      }
-    },
-    "/protocol_subscriptions/delegated_protocol_subscriptions": {
-      "get": {
-        "summary": "Lists all my students their protocolsubscriptions",
-        "tags": [
-          "ProtocolSubscription"
-        ],
-        "consumes": [
-          "application/json"
-        ],
-        "security": [
-          {
-            "JwtAuth": {
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "all delegated protocol subscriptions returned",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "person_type": {
+                  },
+                  "name": {
                     "type": "string"
                   },
-                  "protocol_completion": {
+                  "questionnaires": {
                     "type": "array"
                   },
-                  "earned_euros": {
-                    "type": "number"
-                  },
-                  "max_still_awardable_euros": {
-                    "type": "number"
-                  },
-                  "euro_delta": {
-                    "type": "number"
-                  },
-                  "current_multiplier": {
-                    "type": "number"
-                  },
-                  "max_streak": {
-                    "type": "null"
-                  },
-                  "initial_multiplier": {
-                    "type": "number"
+                  "first_name": {
+                    "type": "string"
                   }
                 }
               }


### PR DESCRIPTION
- Fix invitation set bug with multiple responses in an invitationset the link would no longer work for non mentors if the first response in the invitation set was filled out. (Fixed SDV bug with Sunday questionnaire reminders).
- Adds option for u-can-feel to allow login through UUID (to hopefully fix Outlook/Edge/... redirect/cookie setting issues). This new setting defaults to false for all projects except u-can-feel.