### PR TITLE
Draft: [40588882] Add support for supporting different questionnaire renderers Complete Task

### DIFF
--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -288,16 +288,23 @@ class QuestionnaireController < ApplicationController
   end
 
   def set_questionnaire_content
-    @content = QuestionnaireGenerator.new.generate_questionnaire(
-      response_id: @response.id,
-      content: @response.measurement.questionnaire.content,
-      title: @response.measurement.questionnaire.title,
-      submit_text: (@response.person.locale == 'en' ? 'Save' : 'Opslaan'),
-      action: '/',
-      unsubscribe_url: @response.unsubscribe_url,
-      locale: @response.person.locale,
-      params: default_questionnaire_params
-    )
+    use_new_renderer = questionnaire_params[:new_renderer]
+
+    if use_new_renderer.present? && use_new_renderer.downcase == 'true'
+      @renderer = :new
+      @content = @response.measurement.questionnaire.content
+    else
+      @content = QuestionnaireGenerator.new.generate_questionnaire(
+        response_id: @response.id,
+        content: @response.measurement.questionnaire.content,
+        title: @response.measurement.questionnaire.title,
+        submit_text: (@response.person.locale == 'en' ? 'Save' : 'Opslaan'),
+        action: '/',
+        unsubscribe_url: @response.unsubscribe_url,
+        locale: @response.person.locale,
+        params: default_questionnaire_params
+      )
+    end
   end
 
   def default_questionnaire_params
@@ -308,7 +315,7 @@ class QuestionnaireController < ApplicationController
   end
 
   def questionnaire_params
-    params.permit(:uuid, :method, :callback_url)
+    params.permit(:uuid, :method, :new_renderer, :callback_url)
   end
 
   def questionnaire_create_params

--- a/app/javascript/components/Questionnaire.jsx
+++ b/app/javascript/components/Questionnaire.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import { Questionnaire } from 'sdv-questionnaire-test-renderer'
+
+export default Questionnaire

--- a/app/views/questionnaire/show.html.haml
+++ b/app/views/questionnaire/show.html.haml
@@ -1,2 +1,5 @@
 = render partial: 'shared/header'
-= @content
+- if @renderer == :new
+  = react_component('Questionnaire', props= {content: @content})
+- else
+  = @content

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1",
     "react_ujs": "^2.6.0",
+    "sdv-questionnaire-test-renderer": "^1.0.0",
     "typescript": "^3.5.3",
     "webpack": "^4.39.2",
     "webpack-cli": "^3.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8551,6 +8551,11 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+sdv-questionnaire-test-renderer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sdv-questionnaire-test-renderer/-/sdv-questionnaire-test-renderer-1.0.0.tgz#3260f80f5490fcd41eb454525bfdd1a15fec6db7"
+  integrity sha512-m9WaJSz1BrdpXE+FPO5MtVT3noVtBQmXVxlFCRVr+X65NMYLsUEBft8wYPoud5q2BSimblMHmO2FU1gw56vM9Q==
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"


### PR DESCRIPTION
# Description of feature
Adds a new_renderer parameter to the `/questionnaire` route which, if set to `'true'`, will use react to render the questionnaire rather than the current method.

The react renderer is imported from an external npm library that can be found here: https://www.npmjs.com/package/sdv-questionnaire-test-renderer.

# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.
