### PR TITLE
Fix ostrc start times

### DIFF
--- a/projects/sport-data-valley/seeds/protocols/ostrc_h_o.rb
+++ b/projects/sport-data-valley/seeds/protocols/ostrc_h_o.rb
@@ -26,7 +26,8 @@ db_measurement = protocol.measurements.where(questionnaire_id: ostrc_h_o_questio
 db_measurement ||= protocol.measurements.build(questionnaire_id: ostrc_h_o_questionnaire_id)
 db_measurement.period = 1.week
 db_measurement.open_duration = 1.day
-db_measurement.open_from_offset = 7.hours
+# db_measurement.open_from_offset = 7.hours # Only needed when we also specify the open_from_day.
+#                                             Otherwise it just leads to confusion.
 # Jelte mentioned that it should actually start from the moment you
 # start the protocol, not on mondays.
 # db_measurement.open_from_day = 'monday'

--- a/projects/sport-data-valley/seeds/protocols/ostrc_h_o.rb
+++ b/projects/sport-data-valley/seeds/protocols/ostrc_h_o.rb
@@ -26,11 +26,11 @@ db_measurement = protocol.measurements.where(questionnaire_id: ostrc_h_o_questio
 db_measurement ||= protocol.measurements.build(questionnaire_id: ostrc_h_o_questionnaire_id)
 db_measurement.period = 1.week
 db_measurement.open_duration = 1.day
-# db_measurement.open_from_offset = 7.hours # Only needed when we also specify the open_from_day.
-#                                             Otherwise it just leads to confusion.
+db_measurement.open_from_offset = 0 # Only needed when we also specify the open_from_day.
+#                                     Otherwise it just leads to confusion.
 # Jelte mentioned that it should actually start from the moment you
 # start the protocol, not on mondays.
-# db_measurement.open_from_day = 'monday'
+db_measurement.open_from_day = nil
 db_measurement.reward_points = 0
 db_measurement.stop_measurement = true
 db_measurement.should_invite = true

--- a/projects/sport-data-valley/seeds/protocols/ostrc_o.rb
+++ b/projects/sport-data-valley/seeds/protocols/ostrc_o.rb
@@ -26,11 +26,11 @@ db_measurement = protocol.measurements.where(questionnaire_id: ostrc_questionnai
 db_measurement ||= protocol.measurements.build(questionnaire_id: ostrc_questionnaire_id)
 db_measurement.period = 1.week
 db_measurement.open_duration = 1.day
-# db_measurement.open_from_offset = 7.hours # Only needed when we also specify the open_from_day.
-#                                             Otherwise it just leads to confusion.
+db_measurement.open_from_offset = 0 # Only needed when we also specify the open_from_day.
+#                                     Otherwise it just leads to confusion.
 # Jelte mentioned that it should actually start from the moment you
 # start the protocol, not on mondays.
-# db_measurement.open_from_day = 'monday'
+db_measurement.open_from_day = nil
 db_measurement.reward_points = 0
 db_measurement.stop_measurement = true
 db_measurement.should_invite = true

--- a/projects/sport-data-valley/seeds/protocols/ostrc_o.rb
+++ b/projects/sport-data-valley/seeds/protocols/ostrc_o.rb
@@ -26,7 +26,8 @@ db_measurement = protocol.measurements.where(questionnaire_id: ostrc_questionnai
 db_measurement ||= protocol.measurements.build(questionnaire_id: ostrc_questionnaire_id)
 db_measurement.period = 1.week
 db_measurement.open_duration = 1.day
-db_measurement.open_from_offset = 7.hours
+# db_measurement.open_from_offset = 7.hours # Only needed when we also specify the open_from_day.
+#                                             Otherwise it just leads to confusion.
 # Jelte mentioned that it should actually start from the moment you
 # start the protocol, not on mondays.
 # db_measurement.open_from_day = 'monday'


### PR DESCRIPTION
Otherwise we get this:

![chrome_2021-09-01_18-58-51](https://user-images.githubusercontent.com/607965/131713033-aef4490e-cc42-4bae-b25a-bdf20747408b.png)

(i.e., we select 7pm and then the protocol actually starts at 2am because that's 7 hours later. When you removed the `open_from_day`, it also needs to be removed.)

Also, you need to explicitly set the `open_from_day` to `nil`, otherwise it doesn't overwrite that setting in existing protocols.