### PR TITLE
limit cron job to 1 concurrent, also add resource limits for pods

### DIFF
--- a/manifests/cron.yaml
+++ b/manifests/cron.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth
@@ -44,6 +45,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth
@@ -77,6 +79,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth
@@ -110,6 +113,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth
@@ -143,6 +147,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth
@@ -176,6 +181,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth
@@ -209,6 +215,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth
@@ -242,6 +249,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth
@@ -275,6 +283,7 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Replace
           restartPolicy: Never
           imagePullSecrets:
             - name: gitlab-auth

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           limits:
             memory: "1Gi"
           requests:
-            memory: "256Mi"
+            memory: "350Mi"
         - name: svc-questionnaires
           imagePullPolicy: Always
           image: registry.gitlab.com/researchable/sport-data-valley/mvp/svc-questionnaires:__CI_COMMIT_SHA__

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -26,6 +26,11 @@ spec:
       imagePullSecrets:
         - name: gitlab-auth
       containers:
+        resources:
+          limits:
+            memory: "1Gi"
+          requests:
+            memory: "256Mi"
         - name: svc-questionnaires
           imagePullPolicy: Always
           image: registry.gitlab.com/researchable/sport-data-valley/mvp/svc-questionnaires:__CI_COMMIT_SHA__

--- a/manifests/worker.yaml
+++ b/manifests/worker.yaml
@@ -24,6 +24,11 @@ spec:
       imagePullSecrets:
         - name: gitlab-auth
       containers:
+        resources:
+          limits:
+            memory: "1Gi"
+          requests:
+            memory: "350Mi"
         - name: svc-questionnaires
           imagePullPolicy: Always
           image: registry.gitlab.com/researchable/sport-data-valley/mvp/svc-questionnaires:__CI_COMMIT_SHA__


### PR DESCRIPTION
# Description of feature
add resource limits for pods & limit number of concurrent cron jobs to 1

# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.
