### PR TITLE
[41491814] Fix questionnaire redirect logic

### DIFF
--- a/app/logic/next_page_finder.rb
+++ b/app/logic/next_page_finder.rb
@@ -7,31 +7,71 @@ class NextPageFinder
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/MethodLength
     def get_next_page(current_user:, previous_response: nil, next_response: nil, params: {})
-      return previous_response.measurement.redirect_url if previous_response&.measurement&.redirect_url
+      # if we just filled out a response
+      if previous_response.present?
+        if previous_response.measurement.redirect_url.present? &&
+           !previous_response.measurement.only_redirect_if_nothing_else_ready?
+          previous_response.measurement.redirect_url
+        else
+          # if we just filled out an otr response or a non-otr response,
+          # rule: never redirect to an otr response (unless the next_reponse given as argument is an otr_response).
+          # NOTE: here we choose to redirect to non-otr response even after filling out an otr response. we assume that
+          # this is the desired behavior.
 
-      # If we come from an OTR, we never want to be redirected to the next response lined up
-      return klaar_path if previous_response&.protocol&.otr_protocol?
+          # if there is a next non otr response ready and (i am not a mentor or it is filled out for myself)
+          # (my_open_responses only returns non-OTR responses)
+          next_response ||= current_user.my_open_responses(current_user.mentor?).first
+          if next_response.present? && not_a_mentor_or_filled_out_for_myself?(next_response, current_user)
+            url_to_response(next_response, params)
+          else
+            url_to_exit_flow(current_user, previous_response)
+          end
+        end
+      else
+        # we did not just fill out a response.
+        # only redirect back to redirect_url/klaar_path/mentor_overview_page if there is no response to redirect to
 
-      # If the person is a mentor, then we don't want to automatically redirect to responses filled out for other users.
-      # If the person is not a mentor, then we do (because we use the filling out for another person as a way to give
-      # another person access to the questionnaire response).
-      next_response ||= current_user.my_open_responses(current_user.mentor?).first
-
-      # We only want to schedule OTRs when we're not in a normal questionnaire
-      next_response ||= current_user.all_my_open_one_time_responses.first if previous_response.blank?
-
-      return mentor_overview_index_path if current_user.mentor? && !next_response&.protocol_subscription&.for_myself?
-
-      return questionnaire_path(uuid: next_response.uuid, **params) if next_response.present?
-
-      next_response = current_user.my_open_responses(false).first
-      return questionnaire_path(uuid: next_response.uuid, **params) if next_response.present?
-
-      klaar_path
+        # redirect to next non otr response (if there is one to be filled out for myself or i am not a mentor)
+        next_response ||= current_user.my_open_responses(current_user.mentor?).first
+        # otherwise redirect to next otr response
+        next_response ||= current_user.all_my_open_one_time_responses.first
+        if next_response.present? && not_a_mentor_or_filled_out_for_myself?(next_response, current_user)
+          url_to_response(next_response, params)
+        else
+          url_to_exit_flow(current_user, previous_response)
+        end
+      end
     end
+    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/AbcSize
+
+    private
+
+    def otr_response?(response)
+      response.protocol.otr_protocol?
+    end
+
+    def url_to_response(response, params)
+      questionnaire_path(uuid: response.uuid, **params)
+    end
+
+    def not_a_mentor_or_filled_out_for_myself?(response, current_user)
+      !current_user.mentor? || response.protocol_subscription.for_myself?
+    end
+
+    def url_to_exit_flow(current_user, previous_response)
+      # If there is a redirect_url on the previous response, redirect to it.
+      if previous_response && previous_response.measurement.redirect_url.present?
+        previous_response.measurement.redirect_url
+      elsif current_user.mentor? # if we are a mentor redirect to the mentor overview page
+        mentor_overview_index_path
+      else # otherwise to the done route
+        klaar_path
+      end
+    end
   end
 end

--- a/app/logic/next_page_finder.rb
+++ b/app/logic/next_page_finder.rb
@@ -4,10 +4,7 @@ class NextPageFinder
   class << self
     include Rails.application.routes.url_helpers
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/MethodLength
     def get_next_page(current_user:, previous_response: nil, next_response: nil, params: {})
       # if we just filled out a response
       if previous_response.present?
@@ -23,11 +20,7 @@ class NextPageFinder
           # if there is a next non otr response ready and (i am not a mentor or it is filled out for myself)
           # (my_open_responses only returns non-OTR responses)
           next_response ||= current_user.my_open_responses(current_user.mentor?).first
-          if next_response.present? && not_a_mentor_or_filled_out_for_myself?(next_response, current_user)
-            url_to_response(next_response, params)
-          else
-            url_to_exit_flow(current_user, previous_response)
-          end
+          url_to_response_or_exit_flow(current_user, previous_response, next_response, params)
         end
       else
         # we did not just fill out a response.
@@ -37,22 +30,19 @@ class NextPageFinder
         next_response ||= current_user.my_open_responses(current_user.mentor?).first
         # otherwise redirect to next otr response
         next_response ||= current_user.all_my_open_one_time_responses.first
-        if next_response.present? && not_a_mentor_or_filled_out_for_myself?(next_response, current_user)
-          url_to_response(next_response, params)
-        else
-          url_to_exit_flow(current_user, previous_response)
-        end
+        url_to_response_or_exit_flow(current_user, previous_response, next_response, params)
       end
     end
-    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/AbcSize
 
     private
 
-    def otr_response?(response)
-      response.protocol.otr_protocol?
+    def url_to_response_or_exit_flow(current_user, previous_response, next_response, params)
+      if next_response.present? && not_a_mentor_or_filled_out_for_myself?(next_response, current_user)
+        url_to_response(next_response, params)
+      else
+        url_to_exit_flow(current_user, previous_response)
+      end
     end
 
     def url_to_response(response, params)

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -22,6 +22,8 @@ class Measurement < ApplicationRecord
   validates :protocol_id, presence: true
   validates :stop_measurement, inclusion: { in: [true, false] }
   validates :should_invite, inclusion: { in: [true, false] }
+  # Only redirect if nothing else ready to be filled out (defaults to false).
+  validates :only_redirect_if_nothing_else_ready, inclusion: { in: [true, false] }
   # period can be nil, in which case the questionnaire is one-off and not repeated
   validates :period, numericality: { only_integer: true, allow_nil: true, greater_than: 0 }
   # open_duration can be nil, in which case the questionnaire can be filled out until the end of the protocol

--- a/db/migrate/20210917103012_add_only_redirect_if_nothing_else_ready_to_measurement.rb
+++ b/db/migrate/20210917103012_add_only_redirect_if_nothing_else_ready_to_measurement.rb
@@ -1,0 +1,5 @@
+class AddOnlyRedirectIfNothingElseReadyToMeasurement < ActiveRecord::Migration[6.1]
+  def change
+    add_column :measurements, :only_redirect_if_nothing_else_ready, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_28_192805) do
+ActiveRecord::Schema.define(version: 2021_09_17_103012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2021_07_28_192805) do
     t.string "open_from_day"
     t.integer "priority"
     t.boolean "collapse_duplicates", default: true, null: false
+    t.boolean "only_redirect_if_nothing_else_ready", default: false, null: false
     t.index ["protocol_id"], name: "index_measurements_on_protocol_id"
     t.index ["questionnaire_id"], name: "index_measurements_on_questionnaire_id"
   end

--- a/projects/sport-data-valley/seeds/protocols/daily_protocol.rb
+++ b/projects/sport-data-valley/seeds/protocols/daily_protocol.rb
@@ -55,6 +55,7 @@ days.each_with_index do |day, offset|
   general_daily_measurement.should_invite = true # send invitations
   general_daily_measurement.reminder_delay = reminder_offset
   general_daily_measurement.redirect_url = ENV['BASE_PLATFORM_URL']
+  general_daily_measurement.only_redirect_if_nothing_else_ready = true
   general_daily_measurement.save!
 end
 
@@ -73,5 +74,6 @@ sunday_measurement.reward_points = 0
 sunday_measurement.priority = 2
 sunday_measurement.should_invite = true # send invitations
 sunday_measurement.reminder_delay = reminder_offset
-sunday_measurement.redirect_url = nil # Don't redirect because we have another questionnaire to fill out
+sunday_measurement.redirect_url = ENV['BASE_PLATFORM_URL']
+sunday_measurement.only_redirect_if_nothing_else_ready = true
 sunday_measurement.save!

--- a/projects/sport-data-valley/seeds/protocols/ostrc_h_o.rb
+++ b/projects/sport-data-valley/seeds/protocols/ostrc_h_o.rb
@@ -36,4 +36,5 @@ db_measurement.stop_measurement = true
 db_measurement.should_invite = true
 db_measurement.reminder_delay = 9.hours
 db_measurement.redirect_url = ENV['BASE_PLATFORM_URL']
+db_measurement.only_redirect_if_nothing_else_ready = true
 db_measurement.save!

--- a/projects/sport-data-valley/seeds/protocols/ostrc_o.rb
+++ b/projects/sport-data-valley/seeds/protocols/ostrc_o.rb
@@ -36,4 +36,5 @@ db_measurement.stop_measurement = true
 db_measurement.should_invite = true
 db_measurement.reminder_delay = 9.hours
 db_measurement.redirect_url = ENV['BASE_PLATFORM_URL']
+db_measurement.only_redirect_if_nothing_else_ready = true
 db_measurement.save!

--- a/projects/sport-data-valley/seeds/protocols/restq.rb
+++ b/projects/sport-data-valley/seeds/protocols/restq.rb
@@ -32,4 +32,5 @@ db_measurement.stop_measurement = true
 db_measurement.should_invite = true
 db_measurement.reminder_delay = 4.hours
 db_measurement.redirect_url = ENV['BASE_PLATFORM_URL']
+db_measurement.only_redirect_if_nothing_else_ready = true
 db_measurement.save!

--- a/projects/sport-data-valley/seeds/protocols/squash.rb
+++ b/projects/sport-data-valley/seeds/protocols/squash.rb
@@ -32,4 +32,5 @@ db_measurement.stop_measurement = true
 db_measurement.should_invite = true
 db_measurement.reminder_delay = 4.hours
 db_measurement.redirect_url = ENV['BASE_PLATFORM_URL']
+db_measurement.only_redirect_if_nothing_else_ready = true
 db_measurement.save!

--- a/projects/sport-data-valley/seeds/protocols/squash_otr.rb
+++ b/projects/sport-data-valley/seeds/protocols/squash_otr.rb
@@ -22,4 +22,5 @@ db_measurement.reward_points = 0
 db_measurement.stop_measurement = true # unsubscribe immediately
 db_measurement.should_invite = false # don't send invitations
 db_measurement.redirect_url = ENV['BASE_PLATFORM_URL']
+db_measurement.only_redirect_if_nothing_else_ready = true
 db_measurement.save!

--- a/projects/sport-data-valley/seeds/protocols/training_log.rb
+++ b/projects/sport-data-valley/seeds/protocols/training_log.rb
@@ -30,6 +30,7 @@ db_measurement.reward_points = 0
 db_measurement.stop_measurement = true
 db_measurement.should_invite = false
 db_measurement.redirect_url = ENV['BASE_PLATFORM_URL']
+db_measurement.only_redirect_if_nothing_else_ready = true
 db_measurement.save!
 
 # Create one time response

--- a/spec/logic/next_page_finder_spec.rb
+++ b/spec/logic/next_page_finder_spec.rb
@@ -104,5 +104,29 @@ describe NextPageFinder do
       expect(result).to_not be_blank
       expect(result).to eq Rails.application.routes.url_helpers.questionnaire_path(uuid: response_normal.first.uuid)
     end
+
+    context 'redirect_url' do
+      it 'redirects to the redirect_url if one is specified' do
+        responses = FactoryBot.create_list(:response, 10)
+        allow(person).to receive(:my_open_responses).and_return(responses)
+        measurement = FactoryBot.create(:measurement, :with_redirect_url)
+        redirect_url = '/person/edit'
+        previous_response = FactoryBot.create(:response, :completed, measurement: measurement)
+
+        result = described_class.get_next_page(current_user: person, previous_response: previous_response)
+        expect(result).not_to be_blank
+        expect(result).to eq redirect_url
+      end
+      it 'does not redirect to the redirect_url is one is specified but a response is ready and property is set' do
+        responses = FactoryBot.create_list(:response, 10)
+        expect(person).to receive(:my_open_responses).and_return(responses)
+        measurement = FactoryBot.create(:measurement, :with_redirect_url, only_redirect_if_nothing_else_ready: true)
+        previous_response = FactoryBot.create(:response, :completed, measurement: measurement)
+
+        result = described_class.get_next_page(current_user: person, previous_response: previous_response)
+        expect(result).not_to be_blank
+        expect(result).to eq Rails.application.routes.url_helpers.questionnaire_path(uuid: responses.first.uuid)
+      end
+    end
   end
 end

--- a/spec/logic/next_page_finder_spec.rb
+++ b/spec/logic/next_page_finder_spec.rb
@@ -127,6 +127,16 @@ describe NextPageFinder do
         expect(result).not_to be_blank
         expect(result).to eq Rails.application.routes.url_helpers.questionnaire_path(uuid: responses.first.uuid)
       end
+      it 'does redirect to the redirect_url if there are no responses ready' do
+        expect(person).to receive(:my_open_responses).and_return([])
+        measurement = FactoryBot.create(:measurement, :with_redirect_url, only_redirect_if_nothing_else_ready: true)
+        redirect_url = '/person/edit'
+        previous_response = FactoryBot.create(:response, :completed, measurement: measurement)
+
+        result = described_class.get_next_page(current_user: person, previous_response: previous_response)
+        expect(result).not_to be_blank
+        expect(result).to eq redirect_url
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://freedcamp.com/view/2354427/tasks/panel/task/41491814

Extends Measurements with a new property `only_redirect_if_nothing_else_ready`. This property causes the questionnaire engine to redirect to the next response if one is ready even when a redirect url is defined for the measurement.
