### PR TITLE
increase resource request and limit for questionaire engine

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -28,9 +28,9 @@ spec:
       containers:
         resources:
           limits:
-            memory: "1Gi"
+            memory: "1.5Gi"
           requests:
-            memory: "256Mi"
+            memory: "768Mi"
         - name: svc-questionnaires
           imagePullPolicy: Always
           image: registry.gitlab.com/researchable/sport-data-valley/mvp/svc-questionnaires:__CI_COMMIT_SHA__


### PR DESCRIPTION
# Description of feature
 - increase lower bound of memory allocation to more accurately fit acutal usage range (740-1050MB)
 - increase upper bound to 1.5GB, since currently at least 2 pods are within 10MB of the upper limit, and multiple have restarted in the past 24 hours due to out of memory errors
# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.
