### PR TITLE
fix: error message when elastic apm env vars are not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Below is a list of all required ENV variables for production servers.
 
   WORKLESS_ENABLED: <set to 'true' if you want to enable workless>
   
+  ELASTIC_APM_ENABLED: <set to 'true' if you want to report APM metrics to the elastic cluster>
   ELASTIC_APM_URL: <the url to push APM metrics to>
   ELASTIC_APM_SECRET_TOKEN: <the agent token as obtained from /app/apm/settings/agent-keys when creating a new token>
   ELASTIC_APM_SERVICE_NAME: <set this to how you want the service to show up on the elastic observability stack>

--- a/config/elastic_apm.yml
+++ b/config/elastic_apm.yml
@@ -1,3 +1,4 @@
+enabled: <%= ENV["ELASTIC_APM_ENABLED"] == 'true'%>
 server_url: <%= ENV["ELASTIC_APM_URL"] %>
 secret_token: <%= ENV["ELASTIC_APM_SECRET_TOKEN"] %>
 service_name: <%= ENV["ELASTIC_APM_SERVICE_NAME"] %>


### PR DESCRIPTION
# Description of feature
The elastic APM agent will now be disabled by default.

# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.
