### PR TITLE
fix(kubernetes): replace CronJob batch/v1beta1 with batch/v1

### DIFF
--- a/manifests/cron.yaml
+++ b/manifests/cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-daily-at-one-am
@@ -32,7 +32,7 @@ spec:
                   name: svc-questionnaires-secret
                   key: __CI_COMMIT_REF_NAME___API_SECRET
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-daily-at-two-am
@@ -66,7 +66,7 @@ spec:
                   name: svc-questionnaires-secret
                   key: __CI_COMMIT_REF_NAME___API_SECRET
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-daily-at-three-am
@@ -100,7 +100,7 @@ spec:
                   name: svc-questionnaires-secret
                   key: __CI_COMMIT_REF_NAME___API_SECRET
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-daily-at-four-am
@@ -134,7 +134,7 @@ spec:
                   name: svc-questionnaires-secret
                   key: __CI_COMMIT_REF_NAME___API_SECRET
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-daily
@@ -168,7 +168,7 @@ spec:
                   name: svc-questionnaires-secret
                   key: __CI_COMMIT_REF_NAME___API_SECRET
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-hourly
@@ -202,7 +202,7 @@ spec:
                   name: svc-questionnaires-secret
                   key: __CI_COMMIT_REF_NAME___API_SECRET
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-thirty-minutely
@@ -236,7 +236,7 @@ spec:
                   name: svc-questionnaires-secret
                   key: __CI_COMMIT_REF_NAME___API_SECRET
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-five-minutely
@@ -270,7 +270,7 @@ spec:
                   name: svc-questionnaires-secret
                   key: __CI_COMMIT_REF_NAME___API_SECRET
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-minutely


### PR DESCRIPTION
Fixes the below output from Pluto in preparation of the k8s 1.25 upgrade

```
NAME                                            NAMESPACE        KIND                  VERSION          REPLACEMENT   DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN  
svc-questionnaire-scheduler-daily               sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
svc-questionnaire-scheduler-daily-at-four-am    sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
svc-questionnaire-scheduler-daily-at-one-am     sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
svc-questionnaire-scheduler-daily-at-three-am   sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
svc-questionnaire-scheduler-daily-at-two-am     sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
svc-questionnaire-scheduler-five-minutely       sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
svc-questionnaire-scheduler-hourly              sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
svc-questionnaire-scheduler-minutely            sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
svc-questionnaire-scheduler-thirty-minutely     sdv-mvp-master   CronJob               batch/v1beta1    batch/v1      true         v1.21.0         false     v1.25.0     
```

Signed-off-by: Sjouke de Vries <info@sdvservices.nl>

