### PR TITLE
fix: deprecated api version for CronJob

### DIFF
--- a/manifests/cron.yaml
+++ b/manifests/cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: svc-questionnaire-scheduler-daily-at-one-am


### PR DESCRIPTION
The kubernetes batch/v1beta1 API version for the CronJob resources was deprecated 1.21+ and removed in 1.25. This was causing deploys to not go through

# Description of feature
...

# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.
