### PR TITLE
feat: adds interactive / example questionnaire to support post requests

### DIFF
--- a/app/controllers/questionnaire_controller.rb
+++ b/app/controllers/questionnaire_controller.rb
@@ -6,7 +6,7 @@ class QuestionnaireController < ApplicationController
   MAX_DRAWING_LENGTH = 65_536
   include ::IsLoggedIn
   protect_from_forgery prepend: true, with: :exception, except: :create
-  skip_before_action :verify_authenticity_token, only: %i[interactive_render from_json]
+  skip_before_action :verify_authenticity_token, only: %i[interactive_render from_json interactive_post]
   before_action :log_csrf_error, only: %i[create]
   before_action :set_response, only: %i[show preference destroy]
   before_action :set_locale, only: %i[show]
@@ -24,7 +24,7 @@ class QuestionnaireController < ApplicationController
   before_action :check_interactive_content, only: %i[interactive_render]
   before_action :set_interactive_content, only: %i[interactive_render]
   before_action :verify_interactive_content, only: %i[interactive_render]
-  before_action :set_default_content, only: %i[interactive]
+  before_action :set_default_content, only: %i[interactive interactive_post]
 
   def index
     redirect_to NextPageFinder.get_next_page current_user: current_user
@@ -37,6 +37,8 @@ class QuestionnaireController < ApplicationController
   end
 
   def interactive; end
+
+  def interactive_post; end
 
   # This method is used to post results from the interactive questionnaire previewer
   def from_json

--- a/app/views/questionnaire/interactive_post.html.haml
+++ b/app/views/questionnaire/interactive_post.html.haml
@@ -1,0 +1,27 @@
+:javascript
+  $(document).ready( function() {
+    $( "#questionnaire_content #action" ).click(function( event ) {
+      event.preventDefault();
+      $('#action').addClass('disabled').text('Bezig...');
+      var data = {'content': $('#content').val()};
+      $.post( "/questionnaire/interactive_render", data, function( data ) {
+        $( ".result" ).html( data );
+        $('#action').removeClass('disabled').text('Submit');
+        $('html,body').animate({scrollTop: $('#action').offset().top}, 500);
+        questionnaireLoaded();
+      }).fail(function(err) {
+        console.log(err);
+        $( ".result" ).html( err.responseText );
+        $('#action').removeClass('disabled').text('Submit');
+      });
+    });
+  });
+.row
+  %form.col.s12#questionnaire_content
+    .row
+      .input-field.col.s12
+        %textarea#content.materialize-textarea #{@default_content}
+        %label{for: "content"} Questionnaire JSON
+    .row
+      %button.btn.waves-effect.waves-light{name: 'action', id: 'action'} Submit
+.result.mentor

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     collection do
       get 'preference/:uuid', to: 'questionnaire#preference', as: 'preference'
       get :interactive
+      post :interactive_post
       post :interactive_render
       post :from_json
     end


### PR DESCRIPTION
# Description of feature

adds post url: /questionnaire/interactive_post
that is the same as /questionnaire/interactive, only accepts PSOT instead of GET

