### PR TITLE
feat: make connection string keys configurable

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -9,9 +9,12 @@ A Helm chart for SVC Questionnaires
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | secretName | string | `"svc-questionnaires-secret"` | The main secret for reading the environment variables for the questionnaire engine. |
-| databaseSecretName | string | reference to `secretName`| The secret for storing the database credentials. Defaults to the secret as stored in `secretName`. Must have a key called `DATABASE_URL` that contains a single connection string. |
-| redisSecretName | string | reference to `secretName`| The secret for storing the redis credentials. Defaults to the same secret as stored in `secretName`. Must have a key called `REDIS_URL` that contains a single connection string. |
-| mongoSecretName | string | reference to `secretName`| The secret for storing the mongodb credentials. Defaults to the same secret as stored in `secretName`. Must have a key called `MONGODB_URI` that contains a single connection string. |
+| databaseSecretName | string | reference to `secretName`| The secret for storing the database credentials. Defaults to the secret as stored in `secretName`. Must have a key defined in `databaseSecretKey` that contains a connection string. |
+| databaseSecretKey | string | DATABASE_URL | The name of the connection string in the `databaseSecretName` secret. |
+| redisSecretName | string | reference to `secretName`| The secret for storing the redis credentials. Defaults to the same secret as stored in `secretName`. Must have a key defined in `redisSecretKey` that contains a connection string. |
+| redisSecretKey | string | REDIS_URL | The name of the connection string in the `redisSecretName` secret. |
+| mongoSecretName | string | reference to `secretName`| The secret for storing the mongodb credentials. Defaults to the same secret as stored in `secretName`. Must have a key defined in `mongoSecretKey` that contains a connection string. |
+| mongoSecretKey | string | MONGODB_URI | The name of the connection string in the `mongoSecretName` secret. |
 | tag | string | `"latest"` | The tag of the questionnaire engine image to deploy. |
 | appsignalAppEnv | string | `"staging"` | The environment of the AppSignal application. |
 | curlImage | string | `"registry.gitlab.com/researchable/general/docker-images/curl:latest"` | The Docker image for the curl command used in the init container. |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.databaseSecretName | default .Values.secretName }}
-                key: DATABASE_URL
+                key: {{ .Values.databaseSecretKey }}
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
@@ -137,7 +137,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.redisSecretName | default .Values.secretName }}
-                key: REDIS_URL
+                key: {{ .Values.redisSecretKey }}
           - name: TEST_PHONE_NUMBERS
             valueFrom:
               secretKeyRef:
@@ -177,7 +177,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.mongoSecretName | default .Values.secretName }}
-                key: MONGODB_URI
+                key: {{ .Values.mongoSecretKey }}
           ports:
           - containerPort: 3000
             protocol: TCP

--- a/chart/templates/worker.yaml
+++ b/chart/templates/worker.yaml
@@ -61,7 +61,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.databaseSecretName | default .Values.secretName }}
-                key: DATABASE_URL
+                key: {{ .Values.databaseSecretKey }}
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
@@ -136,7 +136,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.redisSecretName | default .Values.secretName }}
-                key: REDIS_URL
+                key: {{ .Values.redisSecretKey }}
           - name: TEST_PHONE_NUMBERS
             valueFrom:
               secretKeyRef:
@@ -176,4 +176,4 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.mongoSecretName | default .Values.secretName }}
-                key: MONGODB_URI
+                key: {{ .Values.mongoSecretKey }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,10 @@
 secretName: svc-questionnaires-secret
 # databaseSecretName: svc-questionnaires-database-credentials
+databaseSecretKey: DATABASE_URL
 # redisSecretName: svc-questionnaires-redis-credentials
+redisSecretKey: REDIS_URL
 # mongoSecretName: svc-questionnaires-mongo-credentials
+mongoSecretKey: MONGODB_URI
 tag: latest
 appsignalAppEnv: staging
 curlImage: registry.gitlab.com/researchable/general/docker-images/curl:latest


### PR DESCRIPTION
The motivation behind this is that the bitnami/redis chart creates a secret with a connection string, but the key in this secret is not defined the way the questionnaire engine expects it.

# Description of feature
...

# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.
