### PR TITLE
feat: add locale to new_person_params

### DIFF
--- a/app/controllers/api/v1/basic_auth_api/person_controller.rb
+++ b/app/controllers/api/v1/basic_auth_api/person_controller.rb
@@ -21,7 +21,11 @@ module Api
           # This endpoint was added for UMO, where we need to sync users and we need their real emails stored so we can
           # invite them to fill in questionnaires. AuthUser.from_token_payload creates a new anonymous user (with no
           # email), so we need to add it manually
-          auth_user.person.update(email: new_person_params[Rails.application.config.settings.metadata_field][:email])
+          auth_user.person.email = new_person_params[Rails.application.config.settings.metadata_field][:email]
+          if new_person_params[Rails.application.config.settings.metadata_field][:locale].present?
+            auth_user.person.locale = new_person_params[Rails.application.config.settings.metadata_field][:locale]
+          end
+          auth_user.person.save
 
           return created(auth_user.person) if auth_user.person.valid?
 
@@ -85,7 +89,7 @@ module Api
 
         def new_person_params
           params.require(:person).permit :sub,
-                                         Rails.application.config.settings.metadata_field => %i[team role email]
+                                         Rails.application.config.settings.metadata_field => %i[team role email locale]
         end
 
         def team_error?(error)

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -238,7 +238,7 @@ describe 'GET /edit', type: :feature, js: true do
         expect(page).to have_content 'Algemeen', wait: 10 # wait for the form to be submitted
         visit edit_person_path
 
-        expect(page).to have_selector("input[value='0698417312']"), wait: 10
+        expect(page).to have_selector("input[value='0698417312']")
         expect(find("[name='person[gender]'][checked]").value).to eq 'male'
       end
 

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -53,6 +53,8 @@ describe 'GET /edit', type: :feature, js: true do
       page.choose('Man', allow_label_click: true)
 
       all('button[type="submit"]').first.click
+      expect(page).to have_content 'Algemeen', wait: 10 # wait for the form to be submitted
+
       visit edit_person_path
 
       expect(page).to have_selector("input[value='new_first']")
@@ -79,6 +81,7 @@ describe 'GET /edit', type: :feature, js: true do
       page.fill_in('person_email', with: 'anew@email.com')
       page.choose('Man', allow_label_click: true)
       all('button[type="submit"]').first.click
+      expect(page).to have_content 'Algemeen', wait: 10 # wait for the form to be submitted
 
       mentor.reload
 
@@ -146,6 +149,7 @@ describe 'GET /edit', type: :feature, js: true do
 
       page.fill_in('person_email', with: 'anew@email.com')
       all('button[type="submit"]').first.click
+      expect(page).to have_content 'Algemeen', wait: 10 # wait for the form to be submitted
 
       solo.reload
 
@@ -231,9 +235,10 @@ describe 'GET /edit', type: :feature, js: true do
         page.choose('Man', allow_label_click: true)
 
         all('button[type="submit"]').first.click
+        expect(page).to have_content 'Algemeen', wait: 10 # wait for the form to be submitted
         visit edit_person_path
 
-        expect(page).to have_selector("input[value='0698417312']")
+        expect(page).to have_selector("input[value='0698417312']"), wait: 10
         expect(find("[name='person[gender]'][checked]").value).to eq 'male'
       end
 
@@ -247,6 +252,7 @@ describe 'GET /edit', type: :feature, js: true do
         page.fill_in('person_mobile_phone', with: '0698417312')
         page.choose('Man', allow_label_click: true)
         all('button[type="submit"]').first.click
+        expect(page).to have_content 'Algemeen', wait: 10 # wait for the form to be submitted
 
         student.reload
 
@@ -289,6 +295,8 @@ describe 'GET /edit', type: :feature, js: true do
         page.choose('Man', allow_label_click: true)
 
         all('button[type="submit"]').first.click
+        expect(page).to have_content 'Algemeen', wait: 10 # wait for the form to be submitted
+
         visit edit_person_path
 
         expect(page).to have_selector("input[value='new_first']")
@@ -314,6 +322,7 @@ describe 'GET /edit', type: :feature, js: true do
         page.fill_in('person_iban', with: 'NL13RTEF0518590011')
         page.choose('Man', allow_label_click: true)
         all('button[type="submit"]').first.click
+        expect(page).to have_content 'Algemeen', wait: 10 # wait for the form to be submitted
 
         student.reload
 

--- a/spec/features/questionnaires_spec.rb
+++ b/spec/features/questionnaires_spec.rb
@@ -1315,7 +1315,7 @@ describe 'GET and POST /', type: :feature, js: true do
       # v1
       page.choose('Nee', allow_label_click: true)
       page.click_on 'Opslaan'
-      expect(page).to have_content('Webapp Begeleiders')
+      expect(page).to have_content('Webapp Begeleiders', wait: 10)
       expect(page).not_to have_content('Succes: De begeleiding voor Jane is gestopt.')
       responseobj.reload
       expect(responseobj.completed_at).to be_within(1.minute).of(Time.zone.now)

--- a/spec/integration/api/v1/basic_auth_api/person_controller_spec.rb
+++ b/spec/integration/api/v1/basic_auth_api/person_controller_spec.rb
@@ -20,7 +20,8 @@ describe 'Person API' do
             properties: {
               team: { type: :string },
               role: { type: :string },
-              email: { type: :string, format: :email }
+              email: { type: :string, format: :email },
+              locale: { type: :string },
             }
           }
         }
@@ -36,7 +37,8 @@ describe 'Person API' do
             Rails.application.config.settings.metadata_field => {
               team: team.name,
               role: team.roles.first.title,
-              email: 'email1@example.com'
+              email: 'email1@example.com',
+              locale: 'en'
             }
           }
         }
@@ -48,6 +50,7 @@ describe 'Person API' do
           expect(auth_user).to be_present
           p = Person.find_by email: 'email1@example.com'
           expect(p).to be_present
+          expect(p.locale).to eq 'en'
         end
       end
 

--- a/spec/integration/api/v1/basic_auth_api/person_controller_spec.rb
+++ b/spec/integration/api/v1/basic_auth_api/person_controller_spec.rb
@@ -21,7 +21,7 @@ describe 'Person API' do
               team: { type: :string },
               role: { type: :string },
               email: { type: :string, format: :email },
-              locale: { type: :string },
+              locale: { type: :string }
             }
           }
         }


### PR DESCRIPTION
# Description of feature
Add locale to new_person_params when creating a Person using basic auth.

# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [x] Added integration tests to test the code within the application as a whole.
