### PR TITLE
feat: update redirect_url to use INFO_SITE_URL (usc-chan)

### DIFF
--- a/projects/usc-chan/seeds/protocols/usc_chan.rb
+++ b/projects/usc-chan/seeds/protocols/usc_chan.rb
@@ -21,7 +21,7 @@ push_subscription.save!
 
 # Add questionnaires
 reminder_offset = 15.minutes
-redirect_url = "#{ENV.fetch('BASE_PLATFORM_URL')}/?source=questionnaire"
+redirect_url = "#{ENV.fetch('INFO_SITE_URL')}/?source=questionnaire"
 
 questionnaire_name = 'usc_chan'
 questionnaire_id = Questionnaire.find_by(name: questionnaire_name)&.id


### PR DESCRIPTION
# Description of feature
Update the redirect_url of the Measurements in usc-chan seeds since the `BASE_PLATFORM` env variable doesn't seem to be picked up correctly.

# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.
