### PR TITLE
Making 'Satisfaction' question in the training log questionnaire optional

### DIFF
--- a/app/assets/javascripts/questionnaire_logic.js.erb
+++ b/app/assets/javascripts/questionnaire_logic.js.erb
@@ -267,6 +267,11 @@ function check_required_controls(event) {
     $('html, body').animate({
       scrollTop: topOffset
     }, 200);
+  } else {
+  // remove the name attribute from all the sliders that have not changed
+  $('div.range-container.notchanged').each(function (_sub_index) {
+    $(this).find('input[type=range]').removeAttr('name');
+  });
   }
   return returnval;
 }

--- a/projects/sport-data-valley/seeds/questionnaires/training_log.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/training_log.rb
@@ -139,12 +139,12 @@ dagboek_content = [
   },
   {
     id: :v7,
-    title: { nl: 'Tevredenheid over training', en: 'Training satisfaction' },
+    title: { nl: 'Tevredenheid over training (optioneel)', en: 'Training satisfaction (optional)' },
     type: :range,
     min: 1,
     max: 5,
     step: 0.5,
-    required: true,
+    required: false,
     ticks: true,
     no_initial_thumb: true,
     labels: [
@@ -158,6 +158,7 @@ dagboek_content = [
   {
     id: :v8,
     type: :textarea,
+    required: false,
     title: { nl: 'Opmerkingen', en: 'Comments' },
     placeholder: { nl: 'Wat wil je nog delen? (optioneel)', en: 'What else would you like to share? (optional)' },
   },
@@ -166,7 +167,7 @@ dagboek_content = [
     title: { nl: 'Plezier tijdens training (optioneel)', en: 'Fun during training (optional)' },
     type: :range,
     min: 1,
-    max: 5,
+    max: 5, 
     step: 0.5,
     required: false,
     ticks: true,


### PR DESCRIPTION
# Description of feature

"Satisfaction" question in the training log is now optional. When type = 'range' values do not have a value the name attribute is removed. Therefore, the browser does not assign a default value to the range questions. 