### PR TITLE
[AUKATI TIME][SVC QUESTIONNAIRES] Start hour dropdown from 12pm instead of 12am (survey settings)

### DIFF
--- a/app/assets/javascripts/questionnaire_logic.js.erb
+++ b/app/assets/javascripts/questionnaire_logic.js.erb
@@ -142,6 +142,51 @@ function time_element() {
   }
 }
 
+function updateSleepDuration() {
+  var bedHours = $('#v2_hours');
+  var bedMinutes = $('#v2_minutes');
+  var wakeHours = $('#v3_hours');
+  var wakeMinutes = $('#v3_minutes');
+  var durationText = $('#sleep-duration-text');
+  var durationInput = $('#sleep_duration_minutes');
+
+  if (durationText.length === 0 || durationInput.length === 0) return;
+
+  var sleepQuestionsVisible = $('.v2_toggle').not('.hidden').length > 0 && $('.v3_toggle').not('.hidden').length > 0;
+  if (!sleepQuestionsVisible) {
+    durationText.text('-');
+    durationInput.val('');
+    return;
+  }
+
+  if (bedHours.length === 0 || bedMinutes.length === 0 || wakeHours.length === 0 || wakeMinutes.length === 0) {
+    durationText.text('-');
+    durationInput.val('');
+    return;
+  }
+
+  var bedtime = (parseInt(bedHours.val(), 10) * 60) + parseInt(bedMinutes.val(), 10);
+  var waketime = (parseInt(wakeHours.val(), 10) * 60) + parseInt(wakeMinutes.val(), 10);
+
+  if (Number.isNaN(bedtime) || Number.isNaN(waketime)) {
+    durationText.text('-');
+    durationInput.val('');
+    return;
+  }
+
+  var durationMinutes = waketime - bedtime;
+  if (durationMinutes < 0) {
+    durationMinutes += 24 * 60;
+  }
+
+  var hours = Math.floor(durationMinutes / 60);
+  var minutes = durationMinutes % 60;
+  var durationLabel = hours + 'h ' + (minutes < 10 ? ('0' + minutes) : minutes) + 'm';
+
+  durationText.text(durationLabel);
+  durationInput.val(durationMinutes);
+}
+
 function addRemoveDisabledClass(buttons, element_class) {
   var currentButton;
   var questionnaireId;
@@ -348,6 +393,9 @@ function questionnaireLoaded() {
   // The line below breaks stuff, just assume that the questionnaire visibilities are correct by default
   //$('input[type=radio][data-hides-questions],input[type=checkbox][data-hides-questions]').each(toggle_hidden_questions);
   $('.otherwise-option').each(toggle_otherwise_field);
+  updateSleepDuration();
+  $('input[type=radio],input[type=checkbox]').change(updateSleepDuration);
+  $('#v2_hours,#v2_minutes,#v3_hours,#v3_minutes').change(updateSleepDuration);
   $('label + div.input-field.inline').click(function () {
     if ($(this).find('input[type=text][disabled]').length) {
       $(this).prev().click();

--- a/app/assets/javascripts/questionnaire_logic.js.erb
+++ b/app/assets/javascripts/questionnaire_logic.js.erb
@@ -177,6 +177,8 @@ function updateSleepDuration() {
   var durationMinutes = waketime - bedtime;
   if (durationMinutes < 0) {
     durationMinutes += 24 * 60;
+  } else if (durationMinutes === 0) {
+    durationMinutes = 24 * 60;
   }
 
   var hours = Math.floor(durationMinutes / 60);

--- a/app/generators/time_generator.rb
+++ b/app/generators/time_generator.rb
@@ -42,10 +42,7 @@ class TimeGenerator < QuestionTypeGenerator
   # rubocop:enable Metrics/ParameterLists
 
   def generate_dropdown(items, id, am_pm)
-    if am_pm
-      items = items.sort_by { |h| h < 12 ? h + 24 : h }
-    end
-
+    items = items.sort_by { |h| h < 12 ? h + 24 : h } if am_pm
     body = []
     items.each do |option|
       option_value = number_to_string(option)

--- a/app/generators/time_generator.rb
+++ b/app/generators/time_generator.rb
@@ -41,6 +41,7 @@ class TimeGenerator < QuestionTypeGenerator
   end
   # rubocop:enable Metrics/ParameterLists
 
+  # rubocop:disable Metrics/PerceivedComplexity
   def generate_dropdown(items, id, am_pm)
     items = items.sort_by { |h| h < 12 ? h + 24 : h } if am_pm
     body = []
@@ -64,3 +65,4 @@ class TimeGenerator < QuestionTypeGenerator
     tag.select(body, name: answer_name(id), id: id, required: true, class: 'browser-default')
   end
 end
+# rubocop:enable Metrics/PerceivedComplexity

--- a/app/generators/time_generator.rb
+++ b/app/generators/time_generator.rb
@@ -42,6 +42,11 @@ class TimeGenerator < QuestionTypeGenerator
   # rubocop:enable Metrics/ParameterLists
 
   def generate_dropdown(items, id, am_pm)
+
+    if am_pm
+      items = items.sort_by { |h| h < 12 ? h + 24 : h } 
+    end
+
     body = []
     items.each do |option|
       option_value = number_to_string(option)
@@ -49,6 +54,8 @@ class TimeGenerator < QuestionTypeGenerator
       if am_pm
         option_string = if option == 12
                           '12 PM'
+                        elsif option == 0
+                          '12 AM'
                         elsif option > 12
                           "#{number_to_string(option - 12)} PM"
                         else

--- a/app/generators/time_generator.rb
+++ b/app/generators/time_generator.rb
@@ -42,9 +42,8 @@ class TimeGenerator < QuestionTypeGenerator
   # rubocop:enable Metrics/ParameterLists
 
   def generate_dropdown(items, id, am_pm)
-
     if am_pm
-      items = items.sort_by { |h| h < 12 ? h + 24 : h } 
+      items = items.sort_by { |h| h < 12 ? h + 24 : h }
     end
 
     body = []
@@ -54,7 +53,7 @@ class TimeGenerator < QuestionTypeGenerator
       if am_pm
         option_string = if option == 12
                           '12 PM'
-                        elsif option == 0
+                        elsif option.zero?
                           '12 AM'
                         elsif option > 12
                           "#{number_to_string(option - 12)} PM"

--- a/app/generators/time_generator.rb
+++ b/app/generators/time_generator.rb
@@ -32,7 +32,8 @@ class TimeGenerator < QuestionTypeGenerator
   # rubocop:disable Metrics/ParameterLists
   def time_dropdown(question_id, from_time, to_time, step, label, raw_label, am_pm)
     elem_id = idify(question_id, raw_label)
-    options = generate_dropdown((from_time...to_time).step(BigDecimal(step.to_s)), elem_id, am_pm)
+    invert = question_id == :v2
+    options = generate_dropdown((from_time...to_time).step(BigDecimal(step.to_s)), elem_id, am_pm, invert)
     options = safe_join([
                           options,
                           tag.label(label)
@@ -42,8 +43,8 @@ class TimeGenerator < QuestionTypeGenerator
   # rubocop:enable Metrics/ParameterLists
 
   # rubocop:disable Metrics/PerceivedComplexity
-  def generate_dropdown(items, id, am_pm)
-    items = items.sort_by { |h| h < 12 ? h + 24 : h } if am_pm
+  def generate_dropdown(items, id, am_pm, invert)
+    items = items.sort_by { |h| h < 12 ? h + 24 : h } if am_pm && invert
     body = []
     items.each do |option|
       option_value = number_to_string(option)

--- a/projects/usc-chan/seeds/questionnaires/usc_chan.rb
+++ b/projects/usc-chan/seeds/questionnaires/usc_chan.rb
@@ -40,7 +40,7 @@ dagboek_content = [
     title: 'Is this your first questionnaire of the day?',
     show_otherwise: false,
     options: [
-      { title: 'Yes', shows_questions: %i[v2 v3 v4 v5] },
+      { title: 'Yes', shows_questions: %i[v2 v3 v3a v4 v5] },
       { title: 'No', shows_questions: %i[v6] }
     ],
   }, {
@@ -67,6 +67,11 @@ dagboek_content = [
     hours_label: 'Hours',
     minutes_label: 'Minutes',
     am_pm: true,
+  }, {
+    id: :v3a,
+    hidden: true,
+    type: :raw,
+    content: '<p class="flow-text">Sleep duration: <strong><span id="sleep-duration-text">-</span></strong></p><input type="hidden" id="sleep_duration_minutes" name="content[sleep_duration_minutes]" />',
   }, {
     id: :v4,
     hidden: true,


### PR DESCRIPTION
Changed the am/pm logic as requested by Beth: starts at pm instead of am, removed 0 am as it does not exist. + display of sleeping hours