### PR TITLE
chore: replace dependabot auto-merge with GitHub native auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,4 +15,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GIT_GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,16 +1,18 @@
-name: 'Merge Dependencies'
+name: 'Auto-merge Dependabot PRs'
 
-on: [pull_request_target]
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Guarantee that commit comes from Dependabot (don't blindly trust external GitHub Actions)
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: 'Checkout repository'
-        uses: actions/checkout@v2.3.4
-      - name: 'Automerge dependency updates from Dependabot'
-        uses: ahmadnassri/action-dependabot-auto-merge@v2.4.0
-        with:
-          github-token: ${{ secrets.GIT_GITHUB_COM_PASSWORD }}
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Replaces the deprecated `ahmadnassri/action-dependabot-auto-merge` action with GitHub's native auto-merge feature.

## Why

Since January 27, 2026, GitHub no longer supports the `@dependabot merge` comment command that the old action relied on.

## How

Uses `gh pr merge --auto --merge` to enable GitHub's built-in auto-merge on Dependabot PRs. Once all required status checks pass, the PR merges automatically.

## Requirements

Auto-merge requires **branch protection rules** with at least one required status check on the target branch. If not already configured, enable this in Settings → Branches → Branch protection rules.

## Other changes

- Trigger: `pull_request_target` → `pull_request`
- Auth: custom PAT → `GITHUB_TOKEN` (sufficient for native auto-merge)