### PR TITLE
fix: dependabot automerge workflow not triggering

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,8 @@
 name: 'Auto-merge Dependabot PRs'
 
-on: pull_request
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
@@ -9,7 +11,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
## Problem

The automerge workflow was not merging Dependabot PRs (e.g. #3983) because:

1. **`github.actor` check is unreliable** — The condition `github.actor == 'dependabot[bot]'` fails when the workflow is re-triggered by a non-dependabot actor (e.g., after a rebase or manual re-run). The actor changes to whoever triggered the event, not the PR author.

2. **`pull_request` trigger has limited permissions** — Dependabot PRs from forks/dependabot branches run with read-only `GITHUB_TOKEN` on `pull_request` events, which can prevent `gh pr merge --auto` from working.

## Fix

- Changed trigger from `pull_request` to `pull_request_target` (runs in the context of the base branch with write permissions)
- Changed condition to `github.event.pull_request.user.login == 'dependabot[bot]'` which checks the PR author, not the event trigger actor
- Added explicit event types: `opened`, `synchronize`, `reopened`