### PR TITLE
fix: pin Node.js and Yarn versions to prevent Heroku build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "engines": {
+    "node": "20.9.0",
+    "yarn": "1.22.19"
+  },
   "name": "u-can-act",
   "private": true,
   "version": "0.1.0",


### PR DESCRIPTION
## Problem

Heroku changed its default Node.js version from 20.9.0 to 24.13.0 and Yarn from 1.22.19 to 1.22.22. This causes `yarn install` to fail during asset precompilation with a 500 error from the npm registry.

Node.js 24 also introduces breaking changes like the `url.parse()` deprecation.

## Fix

Pin Node.js and Yarn to the previously working versions in `package.json`:
- Node.js: 20.9.0
- Yarn: 1.22.19

This follows [Heroku's recommendation](https://devcenter.heroku.com/articles/ruby-support#node-js-support) to explicitly specify versions.