### PR TITLE
fix: add Node.js and Yarn engine compatibility for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
   "browserslist": [
     "defaults"
   ],
+  "engines": {
+    "node": ">= 20",
+    "yarn": "1.x"
+  },
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
## Problem

Heroku changed its default Node.js from 20.9.0 to 24.13.0 and Yarn from 1.22.19 to 1.22.22, causing build failures during asset precompilation.

## Approach

Instead of pinning old versions (as in #3988), this PR adds an `engines` field to `package.json` declaring compatibility with Node.js >= 20 (including 24.x) and Yarn 1.x.

Testing confirmed that:
- `yarn install` succeeds under the new versions
- Webpack/Webpacker compilation runs without Node 24-specific issues
- No code changes were needed — the existing dependencies are compatible

## Changes

- Added `engines` field to `package.json`: `node >= 20`, `yarn 1.x`

Supersedes #3988.