### PR TITLE
fix: add branch update step to dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Update branch with base
+        run: gh pr update-branch --repo "$REPO" "$PR_NUMBER" || true
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GIT_GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
## Problem

Dependabot PRs get stuck because they fall behind the `develop` branch. With branch protection requiring branches to be up-to-date, auto-merge can't complete.

## Fix

Added a `gh pr update-branch` step before enabling auto-merge. This updates the PR branch with the latest base branch changes. When the branch updates, the `synchronize` event re-triggers the workflow, which then enables auto-merge on the now-current branch.