### PR TITLE
fix: upgrade Node.js from 18 to 20 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG NODE_ENV
 
 # Needed for Yarn
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev curl software-properties-common && \
-  curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
   apt-get update && \


### PR DESCRIPTION
The Dockerfile installs Node.js 18 via nodesource, but `package.json` requires `>= 20`. This causes `yarn install --check-files` to fail:

```
error u-can-act@0.1.0: The engine "node" is incompatible with this module. Expected version ">= 20". Got "18.20.8"
```

**Fix:** Change `setup_18.x` → `setup_20.x` in the Dockerfile.