### PR TITLE
fix(questionnaire): add explicit value keys to KCCQ and PROMIS likert options

### DIFF
--- a/projects/sport-data-valley/seeds/questionnaires/kccq.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/kccq.rb
@@ -86,11 +86,11 @@ dagboek_content = [
              en: '<br>2. Over the past 2 weeks, how many times did you have swelling in your feet, ankles or legs when you woke up in the morning?' },
     type: :likert,
     options: [
-      { nl: 'Elke morgen', en: 'Every morning' },
-      { nl: '3 keer of meer per week, maar niet elke dag', en: '3 or more times per week but not every day' },
-      { nl: '1 tot 2 keer per week', en: '1-2 times per week' },
-      { nl: 'Minder dan 1 keer per week', en: 'Less than once a week' },
-      { nl: 'Nooit gedurende de afgelopen 2 weken', en: 'Never over the past 2 weeks' }
+      { title: { nl: 'Elke morgen', en: 'Every morning' }, value: '1' },
+      { title: { nl: '3 keer of meer per week, maar niet elke dag', en: '3 or more times per week but not every day' }, value: '2' },
+      { title: { nl: '1 tot 2 keer per week', en: '1-2 times per week' }, value: '3' },
+      { title: { nl: 'Minder dan 1 keer per week', en: 'Less than once a week' }, value: '4' },
+      { title: { nl: 'Nooit gedurende de afgelopen 2 weken', en: 'Never over the past 2 weeks' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -101,13 +101,13 @@ dagboek_content = [
              en: '<br>3. Over the past 2 weeks, on average, how many times has fatigue limited your ability to do what you wanted?' },
     type: :likert,
     options: [
-      { nl: 'Voortdurend', en: 'All of the time' },
-      { nl: 'Meerdere keren per dag', en: 'Several times per day' },
-      { nl: 'Tenminste 1 keer per dag', en: 'At least once a day' },
-      { nl: '3 keer of meer per week, maar niet elke dag', en: '3 or more times per week but not every day' },
-      { nl: '1 tot 2 keer per week', en: '1-2 times per week' },
-      { nl: 'Minder dan 1 keer per week', en: 'Less than once a week' },
-      { nl: 'Nooit gedurende de afgelopen 2 weken', en: 'Never over the past 2 weeks' }
+      { title: { nl: 'Voortdurend', en: 'All of the time' }, value: '1' },
+      { title: { nl: 'Meerdere keren per dag', en: 'Several times per day' }, value: '2' },
+      { title: { nl: 'Tenminste 1 keer per dag', en: 'At least once a day' }, value: '3' },
+      { title: { nl: '3 keer of meer per week, maar niet elke dag', en: '3 or more times per week but not every day' }, value: '4' },
+      { title: { nl: '1 tot 2 keer per week', en: '1-2 times per week' }, value: '5' },
+      { title: { nl: 'Minder dan 1 keer per week', en: 'Less than once a week' }, value: '6' },
+      { title: { nl: 'Nooit gedurende de afgelopen 2 weken', en: 'Never over the past 2 weeks' }, value: '7' }
     ],
     required: true,
     show_otherwise: false
@@ -118,15 +118,15 @@ dagboek_content = [
              en: '<br>4. Over the past 2 weeks, on average, how many times has shortness of breath limited your ability to do what you wanted?' },
     type: :likert,
     options: [
-      { nl: 'Voortdurend', en: 'All of the time' },
-      { nl: 'Meerdere keren per dag', en: 'Several times per day' },
-      { nl: 'Tenminste 1 keer per dag', en: 'At least once a day' },
-      { nl: '3 keer of meer per week, maar niet elke dag', en: '3 or more times per week but not every day' },
-      { nl: '1 tot 2 keer per week', en: '1-2 times per week' },
-      { nl: 'Minder dan 1 keer per week', en: 'Less than once a week' },
-      { nl: 'Nooit gedurende de afgelopen 2 weken', en: 'Never over the past 2 weeks' }
+      { title: { nl: 'Voortdurend', en: 'All of the time' }, value: '1' },
+      { title: { nl: 'Meerdere keren per dag', en: 'Several times per day' }, value: '2' },
+      { title: { nl: 'Tenminste 1 keer per dag', en: 'At least once a day' }, value: '3' },
+      { title: { nl: '3 keer of meer per week, maar niet elke dag', en: '3 or more times per week but not every day' }, value: '4' },
+      { title: { nl: '1 tot 2 keer per week', en: '1-2 times per week' }, value: '5' },
+      { title: { nl: 'Minder dan 1 keer per week', en: 'Less than once a week' }, value: '6' },
+      { title: { nl: 'Nooit gedurende de afgelopen 2 weken', en: 'Never over the past 2 weeks' }, value: '7' }
     ],
-    required: true, 
+    required: true,
     show_otherwise: false
   },
   {
@@ -135,11 +135,11 @@ dagboek_content = [
              en: '<br>5. Over the past 2 weeks, on average, how many times have you been forced to sleep sitting up in a chair or with at least 3 pillows to prop you up because of shortness of breath?' },
     type: :likert,
     options: [
-      { nl: 'Elke nacht', en: 'Every night' },
-      { nl: '3 keer of meer per week, maar niet elke nacht', en: '3 or more times per week but not every day' },
-      { nl: '1 tot 2 keer per week', en: '1-2 times per week' },
-      { nl: 'Minder dan 1 keer per week', en: 'Less than once a week' },
-      { nl: 'Nooit gedurende de afgelopen 2 weken', en: 'Never over the past 2 weeks' }
+      { title: { nl: 'Elke nacht', en: 'Every night' }, value: '1' },
+      { title: { nl: '3 keer of meer per week, maar niet elke nacht', en: '3 or more times per week but not every day' }, value: '2' },
+      { title: { nl: '1 tot 2 keer per week', en: '1-2 times per week' }, value: '3' },
+      { title: { nl: 'Minder dan 1 keer per week', en: 'Less than once a week' }, value: '4' },
+      { title: { nl: 'Nooit gedurende de afgelopen 2 weken', en: 'Never over the past 2 weeks' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -150,11 +150,11 @@ dagboek_content = [
              en: '<br>6. Over the past 2 weeks, how much has your heart failure limited your enjoyment of life?' },
     type: :likert,
     options: [
-      { nl: 'Heel erg beperkt', en: 'It has extremely limited my enjoyment of life' },
-      { nl: 'Vrij beperkt', en: 'It has limited my enjoyment of life quite a bit' },
-      { nl: 'Matig beperkt', en: 'It has moderately limited my enjoyment of life' },
-      { nl: 'Een klein beetje beperkt', en: 'It has slightly limited my enjoyment of life' },
-      { nl: 'Helemaal niet beperkt', en: 'It has not limited my enjoyment of life at all' }
+      { title: { nl: 'Heel erg beperkt', en: 'It has extremely limited my enjoyment of life' }, value: '1' },
+      { title: { nl: 'Vrij beperkt', en: 'It has limited my enjoyment of life quite a bit' }, value: '2' },
+      { title: { nl: 'Matig beperkt', en: 'It has moderately limited my enjoyment of life' }, value: '3' },
+      { title: { nl: 'Een klein beetje beperkt', en: 'It has slightly limited my enjoyment of life' }, value: '4' },
+      { title: { nl: 'Helemaal niet beperkt', en: 'It has not limited my enjoyment of life at all' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -165,11 +165,11 @@ dagboek_content = [
              en: '<br>7. If you had to spend the rest of your life with your heart failure the way it is right now, how would you feel about this?' },
     type: :likert,
     options: [
-      { nl: 'Helemaal ontevreden', en: 'Not at all satisfied' },
-      { nl: 'Grotendeels ontevreden', en: 'Mostly dissatisfied' },
-      { nl: 'Enigszins tevreden', en: 'Somewhat satisfied' },
-      { nl: 'Grotendeels tevreden', en: 'Mostly satisfied' },
-      { nl: 'Helemaal tevreden', en: 'Completely satisfied' }
+      { title: { nl: 'Helemaal ontevreden', en: 'Not at all satisfied' }, value: '1' },
+      { title: { nl: 'Grotendeels ontevreden', en: 'Mostly dissatisfied' }, value: '2' },
+      { title: { nl: 'Enigszins tevreden', en: 'Somewhat satisfied' }, value: '3' },
+      { title: { nl: 'Grotendeels tevreden', en: 'Mostly satisfied' }, value: '4' },
+      { title: { nl: 'Helemaal tevreden', en: 'Completely satisfied' }, value: '5' }
     ],
     required: true,
     show_otherwise: false

--- a/projects/sport-data-valley/seeds/questionnaires/promis.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/promis.rb
@@ -22,11 +22,11 @@ dagboek_content = [
              en: 'In general, how would you rate your health?' },
     type: :likert,
     options: [
-      { nl: 'Uitstekend', en: 'Excellent' },
-      { nl: 'Heel goed', en: 'Very good' },
-      { nl: 'Goed', en: 'Good' },
-      { nl: 'Redelijk', en: 'Fair' },
-      { nl: 'Slecht', en: 'Poor' }
+      { title: { nl: 'Uitstekend', en: 'Excellent' }, value: '1' },
+      { title: { nl: 'Heel goed', en: 'Very good' }, value: '2' },
+      { title: { nl: 'Goed', en: 'Good' }, value: '3' },
+      { title: { nl: 'Redelijk', en: 'Fair' }, value: '4' },
+      { title: { nl: 'Slecht', en: 'Poor' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -37,11 +37,11 @@ dagboek_content = [
              en: 'In general, how would you rate your quality of life?' },
     type: :likert,
     options: [
-      { nl: 'Uitstekend', en: 'Excellent' },
-      { nl: 'Heel goed', en: 'Very good' },
-      { nl: 'Goed', en: 'Good' },
-      { nl: 'Redelijk', en: 'Fair' },
-      { nl: 'Slecht', en: 'Poor' }
+      { title: { nl: 'Uitstekend', en: 'Excellent' }, value: '1' },
+      { title: { nl: 'Heel goed', en: 'Very good' }, value: '2' },
+      { title: { nl: 'Goed', en: 'Good' }, value: '3' },
+      { title: { nl: 'Redelijk', en: 'Fair' }, value: '4' },
+      { title: { nl: 'Slecht', en: 'Poor' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -61,11 +61,11 @@ dagboek_content = [
              en: 'Are you able to do chores such as vacuuming or yard work?' },
     type: :likert,
     options: [
-      { nl: 'Zonder moeite', en: 'Without any difficulty' },
-      { nl: 'Met een beetje moeite', en: 'With a little difficulty' },
-      { nl: 'Met enige moeite', en: 'With some difficulty' },
-      { nl: 'Met veel moeite', en: 'With much difficulty' },
-      { nl: 'Kan het niet', en: 'Unable to do' }
+      { title: { nl: 'Zonder moeite', en: 'Without any difficulty' }, value: '1' },
+      { title: { nl: 'Met een beetje moeite', en: 'With a little difficulty' }, value: '2' },
+      { title: { nl: 'Met enige moeite', en: 'With some difficulty' }, value: '3' },
+      { title: { nl: 'Met veel moeite', en: 'With much difficulty' }, value: '4' },
+      { title: { nl: 'Kan het niet', en: 'Unable to do' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -76,11 +76,11 @@ dagboek_content = [
              en: 'Are you able to go up and down stairs at a normal pace?' },
     type: :likert,
     options: [
-      { nl: 'Zonder moeite', en: 'Without any difficulty' },
-      { nl: 'Met een beetje moeite', en: 'With a little difficulty' },
-      { nl: 'Met enige moeite', en: 'With some difficulty' },
-      { nl: 'Met veel moeite', en: 'With much difficulty' },
-      { nl: 'Kan het niet', en: 'Unable to do' }
+      { title: { nl: 'Zonder moeite', en: 'Without any difficulty' }, value: '1' },
+      { title: { nl: 'Met een beetje moeite', en: 'With a little difficulty' }, value: '2' },
+      { title: { nl: 'Met enige moeite', en: 'With some difficulty' }, value: '3' },
+      { title: { nl: 'Met veel moeite', en: 'With much difficulty' }, value: '4' },
+      { title: { nl: 'Kan het niet', en: 'Unable to do' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -91,11 +91,11 @@ dagboek_content = [
              en: 'Are you able to go for a walk of at least 15 minutes?' },
     type: :likert,
     options: [
-      { nl: 'Zonder moeite', en: 'Without any difficulty' },
-      { nl: 'Met een beetje moeite', en: 'With a little difficulty' },
-      { nl: 'Met enige moeite', en: 'With some difficulty' },
-      { nl: 'Met veel moeite', en: 'With much difficulty' },
-      { nl: 'Kan het niet', en: 'Unable to do' }
+      { title: { nl: 'Zonder moeite', en: 'Without any difficulty' }, value: '1' },
+      { title: { nl: 'Met een beetje moeite', en: 'With a little difficulty' }, value: '2' },
+      { title: { nl: 'Met enige moeite', en: 'With some difficulty' }, value: '3' },
+      { title: { nl: 'Met veel moeite', en: 'With much difficulty' }, value: '4' },
+      { title: { nl: 'Kan het niet', en: 'Unable to do' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -106,11 +106,11 @@ dagboek_content = [
              en: 'Are you able to run errands and shop?' },
     type: :likert,
     options: [
-      { nl: 'Zonder moeite', en: 'Without any difficulty' },
-      { nl: 'Met een beetje moeite', en: 'With a little difficulty' },
-      { nl: 'Met enige moeite', en: 'With some difficulty' },
-      { nl: 'Met veel moeite', en: 'With much difficulty' },
-      { nl: 'Kan het niet', en: 'Unable to do' }
+      { title: { nl: 'Zonder moeite', en: 'Without any difficulty' }, value: '1' },
+      { title: { nl: 'Met een beetje moeite', en: 'With a little difficulty' }, value: '2' },
+      { title: { nl: 'Met enige moeite', en: 'With some difficulty' }, value: '3' },
+      { title: { nl: 'Met veel moeite', en: 'With much difficulty' }, value: '4' },
+      { title: { nl: 'Kan het niet', en: 'Unable to do' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -121,11 +121,11 @@ dagboek_content = [
              en: 'Does your health now limit you in doing two hours of physical labor?' },
     type: :likert,
     options: [
-      { nl: 'Helemaal niet', en: 'Not at all' },
-      { nl: 'Heel weinig', en: 'Very little' },
-      { nl: 'Enigszins', en: 'Somewhat' },
-      { nl: 'Behoorlijk', en: 'Quite a lot' },
-      { nl: 'Kan het niet', en: 'Cannot do' }
+      { title: { nl: 'Helemaal niet', en: 'Not at all' }, value: '1' },
+      { title: { nl: 'Heel weinig', en: 'Very little' }, value: '2' },
+      { title: { nl: 'Enigszins', en: 'Somewhat' }, value: '3' },
+      { title: { nl: 'Behoorlijk', en: 'Quite a lot' }, value: '4' },
+      { title: { nl: 'Kan het niet', en: 'Cannot do' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -136,11 +136,11 @@ dagboek_content = [
              en: 'Does your health now limit you in doing moderate work around the house, like vacuuming, sweeping floors or carrying in groceries?' },
     type: :likert,
     options: [
-      { nl: 'Helemaal niet', en: 'Not at all' },
-      { nl: 'Heel weinig', en: 'Very little' },
-      { nl: 'Enigszins', en: 'Somewhat' },
-      { nl: 'Behoorlijk', en: 'Quite a lot' },
-      { nl: 'Kan het niet', en: 'Cannot do' }
+      { title: { nl: 'Helemaal niet', en: 'Not at all' }, value: '1' },
+      { title: { nl: 'Heel weinig', en: 'Very little' }, value: '2' },
+      { title: { nl: 'Enigszins', en: 'Somewhat' }, value: '3' },
+      { title: { nl: 'Behoorlijk', en: 'Quite a lot' }, value: '4' },
+      { title: { nl: 'Kan het niet', en: 'Cannot do' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -151,11 +151,11 @@ dagboek_content = [
              en: 'Does your health now limit you in lifting or carrying groceries?' },
     type: :likert,
     options: [
-      { nl: 'Helemaal niet', en: 'Not at all' },
-      { nl: 'Heel weinig', en: 'Very little' },
-      { nl: 'Enigszins', en: 'Somewhat' },
-      { nl: 'Behoorlijk', en: 'Quite a lot' },
-      { nl: 'Kan het niet', en: 'Cannot do' }
+      { title: { nl: 'Helemaal niet', en: 'Not at all' }, value: '1' },
+      { title: { nl: 'Heel weinig', en: 'Very little' }, value: '2' },
+      { title: { nl: 'Enigszins', en: 'Somewhat' }, value: '3' },
+      { title: { nl: 'Behoorlijk', en: 'Quite a lot' }, value: '4' },
+      { title: { nl: 'Kan het niet', en: 'Cannot do' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -166,11 +166,11 @@ dagboek_content = [
              en: 'Does your health now limit you in doing heavy work around the house like scrubbing floors, or lifting or moving heavy furniture?' },
     type: :likert,
     options: [
-      { nl: 'Helemaal niet', en: 'Not at all' },
-      { nl: 'Heel weinig', en: 'Very little' },
-      { nl: 'Enigszins', en: 'Somewhat' },
-      { nl: 'Behoorlijk', en: 'Quite a lot' },
-      { nl: 'Kan het niet', en: 'Cannot do' }
+      { title: { nl: 'Helemaal niet', en: 'Not at all' }, value: '1' },
+      { title: { nl: 'Heel weinig', en: 'Very little' }, value: '2' },
+      { title: { nl: 'Enigszins', en: 'Somewhat' }, value: '3' },
+      { title: { nl: 'Behoorlijk', en: 'Quite a lot' }, value: '4' },
+      { title: { nl: 'Kan het niet', en: 'Cannot do' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -195,11 +195,11 @@ dagboek_content = [
              en: 'I felt worthless.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Vaak', en: 'Often' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Vaak', en: 'Often' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -210,11 +210,11 @@ dagboek_content = [
              en: 'I felt helpless.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Vaak', en: 'Often' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Vaak', en: 'Often' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -225,11 +225,11 @@ dagboek_content = [
              en: 'I felt depressed.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Vaak', en: 'Often' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Vaak', en: 'Often' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -240,11 +240,11 @@ dagboek_content = [
              en: 'I felt hopeless.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Vaak', en: 'Often' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Vaak', en: 'Often' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -264,11 +264,11 @@ dagboek_content = [
              en: 'I have trouble doing all of my regular leisure activities with others.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Meestal', en: 'Usually' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Meestal', en: 'Usually' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -279,11 +279,11 @@ dagboek_content = [
              en: 'I have trouble doing all of the family activities that I want to do.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Meestal', en: 'Usually' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Meestal', en: 'Usually' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -294,11 +294,11 @@ dagboek_content = [
              en: 'I have trouble doing all of my usual work (include work at home).' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Meestal', en: 'Usually' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Meestal', en: 'Usually' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -309,11 +309,11 @@ dagboek_content = [
              en: 'I have trouble doing all of the activities with friends that I want to do.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Meestal', en: 'Usually' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Meestal', en: 'Usually' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -377,11 +377,11 @@ dagboek_content = [
              en: 'I feel fatigued.' },
     type: :likert,
     options: [
-      { nl: 'Helemaal niet', en: 'Not at all' },
-      { nl: 'Een beetje', en: 'A little bit' },
-      { nl: 'Enigszins', en: 'Somewhat' },
-      { nl: 'In vrij hoge mate', en: 'Quite a bit' },
-      { nl: 'In zeer hoge mate', en: 'Very much' }
+      { title: { nl: 'Helemaal niet', en: 'Not at all' }, value: '1' },
+      { title: { nl: 'Een beetje', en: 'A little bit' }, value: '2' },
+      { title: { nl: 'Enigszins', en: 'Somewhat' }, value: '3' },
+      { title: { nl: 'In vrij hoge mate', en: 'Quite a bit' }, value: '4' },
+      { title: { nl: 'In zeer hoge mate', en: 'Very much' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -392,11 +392,11 @@ dagboek_content = [
              en: 'I have trouble starting things because I am tired.' },
     type: :likert,
     options: [
-      { nl: 'Helemaal niet', en: 'Not at all' },
-      { nl: 'Een beetje', en: 'A little bit' },
-      { nl: 'Enigszins', en: 'Somewhat' },
-      { nl: 'In vrij hoge mate', en: 'Quite a bit' },
-      { nl: 'In zeer hoge mate', en: 'Very much' }
+      { title: { nl: 'Helemaal niet', en: 'Not at all' }, value: '1' },
+      { title: { nl: 'Een beetje', en: 'A little bit' }, value: '2' },
+      { title: { nl: 'Enigszins', en: 'Somewhat' }, value: '3' },
+      { title: { nl: 'In vrij hoge mate', en: 'Quite a bit' }, value: '4' },
+      { title: { nl: 'In zeer hoge mate', en: 'Very much' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -407,11 +407,11 @@ dagboek_content = [
              en: 'How run-down did you feel on average?' },
     type: :likert,
     options: [
-      { nl: 'Helemaal niet', en: 'Not at all' },
-      { nl: 'Een beetje', en: 'A little bit' },
-      { nl: 'Enigszins', en: 'Somewhat' },
-      { nl: 'Behoorlijk', en: 'Quite a bit' },
-      { nl: 'Heel erg', en: 'Very much' }
+      { title: { nl: 'Helemaal niet', en: 'Not at all' }, value: '1' },
+      { title: { nl: 'Een beetje', en: 'A little bit' }, value: '2' },
+      { title: { nl: 'Enigszins', en: 'Somewhat' }, value: '3' },
+      { title: { nl: 'Behoorlijk', en: 'Quite a bit' }, value: '4' },
+      { title: { nl: 'Heel erg', en: 'Very much' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -422,11 +422,11 @@ dagboek_content = [
              en: 'How fatigued were you on average?' },
     type: :likert,
     options: [
-      { nl: 'Helemaal niet', en: 'Not at all' },
-      { nl: 'Een beetje', en: 'A little bit' },
-      { nl: 'Enigszins', en: 'Somewhat' },
-      { nl: 'Behoorlijk', en: 'Quite a bit' },
-      { nl: 'Heel erg', en: 'Very much' }
+      { title: { nl: 'Helemaal niet', en: 'Not at all' }, value: '1' },
+      { title: { nl: 'Een beetje', en: 'A little bit' }, value: '2' },
+      { title: { nl: 'Enigszins', en: 'Somewhat' }, value: '3' },
+      { title: { nl: 'Behoorlijk', en: 'Quite a bit' }, value: '4' },
+      { title: { nl: 'Heel erg', en: 'Very much' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -451,11 +451,11 @@ dagboek_content = [
              en: 'I felt fearful.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Vaak', en: 'Often' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Vaak', en: 'Often' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -466,11 +466,11 @@ dagboek_content = [
              en: 'I found it hard to focus on anything other than my anxiety.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Vaak', en: 'Often' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Vaak', en: 'Often' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -481,11 +481,11 @@ dagboek_content = [
              en: 'My worries overwhelmed me.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Vaak', en: 'Often' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Vaak', en: 'Often' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false
@@ -496,11 +496,11 @@ dagboek_content = [
              en: 'I felt uneasy.' },
     type: :likert,
     options: [
-      { nl: 'Nooit', en: 'Never' },
-      { nl: 'Zelden', en: 'Rarely' },
-      { nl: 'Soms', en: 'Sometimes' },
-      { nl: 'Vaak', en: 'Often' },
-      { nl: 'Altijd', en: 'Always' }
+      { title: { nl: 'Nooit', en: 'Never' }, value: '1' },
+      { title: { nl: 'Zelden', en: 'Rarely' }, value: '2' },
+      { title: { nl: 'Soms', en: 'Sometimes' }, value: '3' },
+      { title: { nl: 'Vaak', en: 'Often' }, value: '4' },
+      { title: { nl: 'Altijd', en: 'Always' }, value: '5' }
     ],
     required: true,
     show_otherwise: false


### PR DESCRIPTION
## Summary
- KCCQ and PROMIS likert options were defined as simple translation hashes (`{ nl: '...', en: '...' }`) without explicit `value` keys
- The likert generator falls back to using the Dutch display text as the HTML form value, causing responses to store text like `"Uitstekend"` instead of numeric `"1"`
- Added explicit `value` keys to all 33 affected likert options, matching the answer mappings from `kccq_answers.csv` and `promis_answers.csv`

## Changes
- **KCCQ**: 6 likert questions (v2–v7) — values `1`–`5` or `1`–`7`
- **PROMIS**: 27 likert questions (all sections) — values `1`–`5`
- Range-type questions unchanged (already submit numeric values)

## Impact
- No code changes to generators — they already support the `{ title: {...}, value: '...' }` format via `option[:raw][:value].presence || option[:raw][:title]`
- Other questionnaires (daily, RestQ, climbing_accident) are unaffected
- **Note**: Existing stored responses with Dutch text values will not be retroactively changed. After re-seeding, new responses will store numeric keys.

## Test plan
- [ ] Re-seed questionnaires on dev environment
- [ ] Fill in KCCQ and PROMIS questionnaires
- [ ] Verify responses contain numeric values (`"1"`, `"2"`, etc.) instead of Dutch text
- [ ] Verify exported data matches `kccq_answers.csv` / `promis_answers.csv` mappings
- [ ] Verify other questionnaires still work correctly