### PR TITLE
feat(sdv): conditional "next questionnaire" notice on final page

### DIFF
--- a/app/generators/next_questionnaire_notice_generator.rb
+++ b/app/generators/next_questionnaire_notice_generator.rb
@@ -5,8 +5,8 @@ class NextQuestionnaireNoticeGenerator < QuestionTypeGenerator
   WITH_NEXT_SUFFIX = ' en door te gaan naar de volgende vragenlijst'
 
   def generate(question)
-    text = BASE_TEXT + (next_response?(question[:response_id]) ? WITH_NEXT_SUFFIX : '') + '.'
-    tag.p(text, class: 'flow-text')
+    suffix = next_response?(question[:response_id]) ? WITH_NEXT_SUFFIX : ''
+    tag.p("#{BASE_TEXT}#{suffix}.", class: 'flow-text')
   end
 
   private

--- a/app/generators/next_questionnaire_notice_generator.rb
+++ b/app/generators/next_questionnaire_notice_generator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class NextQuestionnaireNoticeGenerator < QuestionTypeGenerator
+  BASE_TEXT = "Klik hieronder op 'Opslaan' om de antwoorden in te leveren"
+  WITH_NEXT_SUFFIX = ' en door te gaan naar de volgende vragenlijst'
+
+  def generate(question)
+    text = BASE_TEXT + (next_response?(question[:response_id]) ? WITH_NEXT_SUFFIX : '') + '.'
+    tag.p(text, class: 'flow-text')
+  end
+
+  private
+
+  def next_response?(current_response_id)
+    response = Response.find_by(id: current_response_id)
+    return false if response.blank?
+
+    person = response.protocol_subscription.person
+    person.my_open_responses(person.mentor?).any? { |r| r.id != response.id }
+  end
+end

--- a/app/generators/questionnaire_question_generator.rb
+++ b/app/generators/questionnaire_question_generator.rb
@@ -13,6 +13,7 @@ class QuestionnaireQuestionGenerator < Generator
       textfield: TextfieldGenerator.new,
       number: NumberGenerator.new,
       raw: RawGenerator.new,
+      next_questionnaire_notice: NextQuestionnaireNoticeGenerator.new,
       unsubscribe: UnsubscribeGenerator.new,
       date: DateGenerator.new,
       dropdown: DropdownGenerator.new,

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -5,7 +5,7 @@ class Questionnaire < ApplicationRecord
 
   KNOWN_OPERATIONS = %i[average sum].freeze
   OPTIONS_REQUIRED_FOR = %i[checkbox likert radio dropdown].freeze
-  QUESTIONS_WITHOUT_TITLES = %i[raw unsubscribe].freeze
+  QUESTIONS_WITHOUT_TITLES = %i[raw unsubscribe next_questionnaire_notice].freeze
   RANGE_QUESTION_TYPES = %i[range].freeze
 
   # This is an ordered array of known preprocessing steps

--- a/projects/sport-data-valley/seeds/questionnaires/actief_transport.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/actief_transport.rb
@@ -308,6 +308,8 @@ dagboek_content = [
       'Tevreden',
       'Zeer tevreden'
     ]
+  }, {
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/ases_rheumatism.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/ases_rheumatism.rb
@@ -42,8 +42,7 @@ dagboek_content = [
     id: :v5,
     title: 'Ik ben er zeker van dat ik de frustraties die ik door mijn reumatische aandoening ondervind, aankan.'
   }), {
-    type: :raw,
-    content: '<p class="flow-text">Klik hieronder op \'Opslaan\' om de antwoorden in te leveren en door te gaan naar de volgende vragenlijst.</p>'
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/braf_rheumatism.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/braf_rheumatism.rb
@@ -116,8 +116,7 @@ dagboek_content = [
     title: 'Hebt u zich somber of depressief gevoeld vanwege vermoeidheid?',
     section_end: true
   }), {
-    type: :raw,
-    content: '<p class="flow-text">Klik hieronder op \'Opslaan\' om de antwoorden in te leveren en door te gaan naar de volgende vragenlijst.</p>'
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/climbing_accident.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/climbing_accident.rb
@@ -512,6 +512,9 @@ question_content = [
       nl: "Heb je nog op- of aanmerkingen aan de hand van deze melding? (optional)",
       en: "Do you have any comments or remarks based on this report? (optional)"
     }
+  },
+  {
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/daily_questionnaire.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/daily_questionnaire.rb
@@ -168,6 +168,7 @@ days.each_with_index do |day, idx|
                                     content: { nl: "<h4 class=\"header\">Dagelijkse vragenlijst #{day}</h4>",
                                                en: "<h4 class=\"header\">Daily questionnaire #{english_day}</h4>" }
                                   })
+  current_dagboek_content.push({ type: :next_questionnaire_notice })
   db_name1 = "daily_questionnaire_#{day}"
   questionnaire = Questionnaire.find_by(name: db_name1)
   questionnaire ||= Questionnaire.new(name: db_name1)

--- a/projects/sport-data-valley/seeds/questionnaires/daily_questionnaire_rheumatism.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/daily_questionnaire_rheumatism.rb
@@ -99,8 +99,7 @@ dagboek_content = [
     type: :textarea,
     title: RheumatismMethods.category_title('Opmerkingen', 'Was er vandaag iets aan de hand (bv ziekte) wat invloed had op één van bovenstaande antwoorden? Zo ja, wat? Of wil je verder nog iets benoemen?')
   }, {
-    type: :raw,
-    content: '<p class="flow-text">Klik hieronder op \'Opslaan\' om de antwoorden in te leveren.</p>'
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/eq5d5l_rheumatism.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/eq5d5l_rheumatism.rb
@@ -77,8 +77,7 @@ dagboek_content = [
     labels: ['De slechtste gezondheid die u zich kunt voorstellen', 'De beste gezondheid die u zich kunt voorstellen'],
     required: true
   }, {
-    type: :raw,
-    content: '<p class="flow-text">Klik hieronder op \'Opslaan\' om de antwoorden in te leveren en door te gaan naar de volgende vragenlijst.</p>'
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/hads_rheumatism.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/hads_rheumatism.rb
@@ -139,8 +139,7 @@ dagboek_content = [
               { title: 'heel zelden', numeric_value: 3 }],
     show_otherwise: false
   }, {
-    type: :raw,
-    content: '<p class="flow-text">Klik hieronder op \'Opslaan\' om de antwoorden in te leveren en door te gaan naar de volgende vragenlijst.</p>'
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/korte_vragenlijst.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/korte_vragenlijst.rb
@@ -138,6 +138,9 @@ dagboek_content = [
       'Tevreden',
       'Zeer tevreden'
     ]
+  },
+  {
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/ostrc_h_o.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/ostrc_h_o.rb
@@ -206,6 +206,9 @@ dagboek_content = [
     min: 0,
     max: 100
   },
+  {
+    type: :next_questionnaire_notice
+  }
 ]
 
 questionnaire.content = {

--- a/projects/sport-data-valley/seeds/questionnaires/ostrc_o.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/ostrc_o.rb
@@ -40,6 +40,9 @@ dagboek_content = [
     min: 0,
     max: 100
   },
+  {
+    type: :next_questionnaire_notice
+  }
 ]
 
 questionnaire.content = {

--- a/projects/sport-data-valley/seeds/questionnaires/psychological_competencies.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/psychological_competencies.rb
@@ -564,7 +564,10 @@ dagboek_content = [
       en: 'I actively communicate to other people when they are crossing my boundaries'
     },
     section_end: true
-  })
+  }),
+  {
+    type: :next_questionnaire_notice
+  }
 ]
 invert = { multiply_with: -1, offset: 100 }
 dagboek1.content = {

--- a/projects/sport-data-valley/seeds/questionnaires/restq.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/restq.rb
@@ -179,6 +179,9 @@ questionnaire_content = [{
   {
     type: :raw,
     content: {en: '<h4>Thank you very much!</h4>', nl: '<h4>Bedankt voor het invullen!</h4>'}
+  },
+  {
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/projects/sport-data-valley/seeds/questionnaires/squash.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/squash.rb
@@ -265,6 +265,7 @@ dagboek_content << {
   }]
 }
 
+dagboek_content << { type: :next_questionnaire_notice }
 
 questionnaire.content = { questions: dagboek_content, scores: [] }
 questionnaire.title = db_title

--- a/projects/sport-data-valley/seeds/questionnaires/training_log.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/training_log.rb
@@ -180,6 +180,9 @@ dagboek_content = [
     title: { nl: 'Opmerkingen', en: 'Comments' },
     placeholder: { nl: 'Wat wil je nog delen? (optioneel)', en: 'What else would you like to share? (optional)' },
     },
+  {
+    type: :next_questionnaire_notice
+  }
 ]
 
 questionnaire.content = { questions: dagboek_content, scores: [] }

--- a/projects/sport-data-valley/seeds/questionnaires/weekly_wellbeing.rb
+++ b/projects/sport-data-valley/seeds/questionnaires/weekly_wellbeing.rb
@@ -98,6 +98,9 @@ dagboek_content = [
     title: { nl: 'Opmerking', en: 'Comment' },
     placeholder: { nl: 'Wat wil je nog delen (optioneel)?', en: 'What else would you like to share (optional)?' },
     type: :textarea
+  },
+  {
+    type: :next_questionnaire_notice
   }
 ]
 

--- a/spec/generators/next_questionnaire_notice_generator_spec.rb
+++ b/spec/generators/next_questionnaire_notice_generator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe NextQuestionnaireNoticeGenerator do
+  subject { described_class.new }
+
+  let(:base_text) { "Klik hieronder op 'Opslaan' om de antwoorden in te leveren" }
+  let(:with_next_suffix) { ' en door te gaan naar de volgende vragenlijst' }
+
+  context 'when there is another open response for the user' do
+    let(:response) { FactoryBot.create(:response) }
+    let(:other_response) { FactoryBot.create(:response) }
+
+    before do
+      allow(Response).to receive(:find_by).with(id: response.id).and_return(response)
+      allow(response.protocol_subscription.person).to receive(:my_open_responses)
+        .and_return([response, other_response])
+    end
+
+    it 'renders the notice with the "next questionnaire" suffix' do
+      result = subject.generate(response_id: response.id)
+      expect(result).to include(base_text + with_next_suffix + '.')
+    end
+  end
+
+  context 'when the current response is the only open one' do
+    let(:response) { FactoryBot.create(:response) }
+
+    before do
+      allow(Response).to receive(:find_by).with(id: response.id).and_return(response)
+      allow(response.protocol_subscription.person).to receive(:my_open_responses)
+        .and_return([response])
+    end
+
+    it 'renders the short notice without mentioning the next questionnaire' do
+      result = subject.generate(response_id: response.id)
+      expect(result).to include(base_text + '.')
+      expect(result).not_to include('volgende vragenlijst')
+    end
+  end
+
+  context 'when response_id is nil (preview mode)' do
+    it 'renders the short notice without raising' do
+      result = subject.generate(response_id: nil)
+      expect(result).to include(base_text + '.')
+      expect(result).not_to include('volgende vragenlijst')
+    end
+  end
+end

--- a/spec/generators/next_questionnaire_notice_generator_spec.rb
+++ b/spec/generators/next_questionnaire_notice_generator_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 describe NextQuestionnaireNoticeGenerator do
   subject { described_class.new }
 
-  let(:base_text) { "Klik hieronder op 'Opslaan' om de antwoorden in te leveren" }
-  let(:with_next_suffix) { ' en door te gaan naar de volgende vragenlijst' }
+  let(:base_phrase) { 'om de antwoorden in te leveren' }
+  let(:next_phrase) { 'door te gaan naar de volgende vragenlijst' }
 
   context 'when there is another open response for the user' do
     let(:response) { FactoryBot.create(:response) }
@@ -20,7 +20,8 @@ describe NextQuestionnaireNoticeGenerator do
 
     it 'renders the notice with the "next questionnaire" suffix' do
       result = subject.generate(response_id: response.id)
-      expect(result).to include(base_text + with_next_suffix + '.')
+      expect(result).to include(base_phrase)
+      expect(result).to include(next_phrase)
     end
   end
 
@@ -35,16 +36,16 @@ describe NextQuestionnaireNoticeGenerator do
 
     it 'renders the short notice without mentioning the next questionnaire' do
       result = subject.generate(response_id: response.id)
-      expect(result).to include(base_text + '.')
-      expect(result).not_to include('volgende vragenlijst')
+      expect(result).to include(base_phrase)
+      expect(result).not_to include(next_phrase)
     end
   end
 
   context 'when response_id is nil (preview mode)' do
     it 'renders the short notice without raising' do
       result = subject.generate(response_id: nil)
-      expect(result).to include(base_text + '.')
-      expect(result).not_to include('volgende vragenlijst')
+      expect(result).to include(base_phrase)
+      expect(result).not_to include(next_phrase)
     end
   end
 end


### PR DESCRIPTION
Add a :next_questionnaire_notice content block type that renders "Klik op Opslaan om de antwoorden in te leveren" and appends "en door te gaan naar de volgende vragenlijst" only when the user has another pending response. Previously this was hardcoded in four rheumatism questionnaires and shown even when no next questionnaire existed, which was misleading to users.

Apply the new notice as the final content block in every SDV questionnaire for consistent end-of-questionnaire messaging.

# Description of feature
...

# Checklist
- [ ] (If applicable) added example values of new ENV variables to .env.local and explained them in README.md.
- [ ] Added unit tests to test the code.
- [ ] Added integration tests to test the code within the application as a whole.
