### PR TITLE
fix: update test expectations for Ruby 3.4 Hash#inspect format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: cimg/ruby:3.2.3-browsers
+    - image: cimg/ruby:3.4.9-browsers
     - image: cimg/redis:7.0
       command: redis-server --requirepass redispassword
       environment:
@@ -22,7 +22,7 @@ defaults: &defaults
 
 build_defaults: &build_defaults
   docker:
-    - image: cimg/ruby:3.2.3-browsers
+    - image: cimg/ruby:3.4.9-browsers
   environment:
     TZ: "/usr/share/zoneinfo/Europe/Amsterdam"
     RAILS_ENV: test
@@ -49,7 +49,7 @@ jobs:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
-      - run: gem install bundler:2.1.4 # Later version might give problems installing libv8, see https://github.com/rubyjs/libv8/issues/310
+      - run: gem install bundler
       - run: bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
@@ -78,7 +78,7 @@ jobs:
       TZ: "/usr/share/zoneinfo/Europe/Amsterdam"
       RAILS_ENV: test
       RACK_ENV: test
-      COVERALLS_PARALLEL: 'true'
+      COVERALLS_PARALLEL: "true"
     parallelism: 3
     steps:
       - restore_cache:
@@ -89,7 +89,7 @@ jobs:
           name: Restore Yarn Package Cache
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
-      - run: gem install bundler:2.1.4
+      - run: gem install bundler
       - run: bundle --path vendor/bundle
       - run: bundle exec rake i18n:js:export
       - run: yarn install
@@ -111,7 +111,7 @@ jobs:
                               --format RspecJunitFormatter \
                               --out /tmp/test-results/rspec.xml \
                               -- $(echo "${TEST_FILES}" | sed -e 's/\n/\\n/' -e 's/ /\ /')
-      - store_test_results:   # TEST_FILES contains newlines, replace by spaces or we get errors
+      - store_test_results: # TEST_FILES contains newlines, replace by spaces or we get errors
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
@@ -136,28 +136,28 @@ jobs:
           name: Restore Yarn Package Cache
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
-      - run: gem install bundler:2.1.4
+      - run: gem install bundler
       - run: bundle --path vendor/bundle
       - run: bundle exec rake i18n:js:export
       - run: yarn install
       - run: yarn test
 
-#  test_translations:
-#    <<: *build_defaults
-#    steps:
-#      - restore_cache:
-#          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
-#      - restore_cache:
-#          key: v1-bundle-{{ checksum "Gemfile.lock" }}
-#      - restore_cache:
-#          name: Restore Yarn Package Cache
-#          keys:
-#            - yarn-packages-{{ checksum "yarn.lock" }}
-#      - run: gem install bundler:2.1.4
-#      - run: bundle --path vendor/bundle
-#      - run: yarn install
-#      - run: 'echo PROJECT_NAME: \''Evaluatieonderzoek\'' | tee -a .env.local'
-#      - run: RAILS_ENV=development bin/check_translations.sh
+  #  test_translations:
+  #    <<: *build_defaults
+  #    steps:
+  #      - restore_cache:
+  #          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
+  #      - restore_cache:
+  #          key: v1-bundle-{{ checksum "Gemfile.lock" }}
+  #      - restore_cache:
+  #          name: Restore Yarn Package Cache
+  #          keys:
+  #            - yarn-packages-{{ checksum "yarn.lock" }}
+  #      - run: gem install bundler:2.1.4
+  #      - run: bundle --path vendor/bundle
+  #      - run: yarn install
+  #      - run: 'echo PROJECT_NAME: \''Evaluatieonderzoek\'' | tee -a .env.local'
+  #      - run: RAILS_ENV=development bin/check_translations.sh
 
   test_rubocop:
     <<: *build_defaults
@@ -166,7 +166,7 @@ jobs:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
-      - run: gem install bundler:2.1.4
+      - run: gem install bundler
       - run: bundle --path vendor/bundle
       - run: bundle exec rubocop
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
-      - run: gem install bundler:2.3.17
+      - run: gem install bundler:2.1.4
       - run: bundle config set path 'vendor/bundle'
       - run:
           name: bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ defaults: &defaults
     RAILS_ENV: test
     RACK_ENV: test
     NODE_ENV: test
+    BUNDLE_WITHOUT: "production staging"
   working_directory: ~/test
 
 build_defaults: &build_defaults
@@ -28,6 +29,7 @@ build_defaults: &build_defaults
     RAILS_ENV: test
     RACK_ENV: test
     NODE_ENV: test
+    BUNDLE_WITHOUT: "production staging"
   working_directory: ~/test
 
 version: 2.1
@@ -48,15 +50,15 @@ jobs:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
-      - run: gem install bundler:2.1.4
+          key: v3-bundle-ruby34-{{ checksum "Gemfile.lock" }}
+      - run: gem install bundler:2.3.17
       - run: bundle config set path 'vendor/bundle'
       - run:
           name: bundle install
           command: bundle install --jobs=1 --retry=3 --verbose
           no_output_timeout: 30m
       - save_cache:
-          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
+          key: v3-bundle-ruby34-{{ checksum "Gemfile.lock" }}
           paths:
             - ~/test/vendor/bundle
 
@@ -83,12 +85,13 @@ jobs:
       RAILS_ENV: test
       RACK_ENV: test
       COVERALLS_PARALLEL: "true"
+      BUNDLE_WITHOUT: "production staging"
     parallelism: 3
     steps:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
+          key: v3-bundle-ruby34-{{ checksum "Gemfile.lock" }}
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
@@ -135,7 +138,7 @@ jobs:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
+          key: v3-bundle-ruby34-{{ checksum "Gemfile.lock" }}
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
@@ -169,7 +172,7 @@ jobs:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
+          key: v3-bundle-ruby34-{{ checksum "Gemfile.lock" }}
       - run: gem install bundler:2.3.17
       - run: bundle config set path 'vendor/bundle'
       - run: bundle exec rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ defaults: &defaults
     - image: mongo:4.4
       environment:
         TZ: "/usr/share/zoneinfo/Europe/Amsterdam"
+  resource_class: large
   environment:
     TZ: "/usr/share/zoneinfo/Europe/Amsterdam"
     RAILS_ENV: test
@@ -24,6 +25,7 @@ defaults: &defaults
 build_defaults: &build_defaults
   docker:
     - image: cimg/ruby:3.4.9-browsers
+  resource_class: large
   environment:
     TZ: "/usr/share/zoneinfo/Europe/Amsterdam"
     RAILS_ENV: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ jobs:
       - restore_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
       - run: gem install bundler
-      - run: bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - run: bundle config set path 'vendor/bundle'
+      - run: bundle install --jobs=4 --retry=3
       - save_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
           paths:
@@ -90,7 +91,7 @@ jobs:
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
       - run: gem install bundler
-      - run: bundle --path vendor/bundle
+      - run: bundle config set path 'vendor/bundle'
       - run: bundle exec rake i18n:js:export
       - run: yarn install
       - run: echo 127.0.0.1 docker.io db redis mongo | sudo tee -a /etc/hosts
@@ -137,7 +138,7 @@ jobs:
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
       - run: gem install bundler
-      - run: bundle --path vendor/bundle
+      - run: bundle config set path 'vendor/bundle'
       - run: bundle exec rake i18n:js:export
       - run: yarn install
       - run: yarn test
@@ -154,7 +155,7 @@ jobs:
   #          keys:
   #            - yarn-packages-{{ checksum "yarn.lock" }}
   #      - run: gem install bundler:2.1.4
-  #      - run: bundle --path vendor/bundle
+  #      - run: bundle config set path 'vendor/bundle'
   #      - run: yarn install
   #      - run: 'echo PROJECT_NAME: \''Evaluatieonderzoek\'' | tee -a .env.local'
   #      - run: RAILS_ENV=development bin/check_translations.sh
@@ -167,7 +168,7 @@ jobs:
       - restore_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
       - run: gem install bundler
-      - run: bundle --path vendor/bundle
+      - run: bundle config set path 'vendor/bundle'
       - run: bundle exec rubocop
 
   coverage_report:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
       - run: gem install bundler:2.3.17
       - run: bundle config set path 'vendor/bundle'
-      - run: bundle install --jobs=4 --retry=3
+      - run: bundle install --jobs=1 --retry=3 --verbose
       - save_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
           paths:
@@ -90,7 +90,7 @@ jobs:
           name: Restore Yarn Package Cache
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
-      - run: gem install bundler
+      - run: gem install bundler:2.3.17
       - run: bundle config set path 'vendor/bundle'
       - run: bundle exec rake i18n:js:export
       - run: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,15 @@ jobs:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-bundle-{{ checksum "Gemfile.lock" }}
+          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
       - run: gem install bundler:2.3.17
       - run: bundle config set path 'vendor/bundle'
-      - run: bundle install --jobs=1 --retry=3 --verbose
+      - run:
+          name: bundle install
+          command: bundle install --jobs=1 --retry=3 --verbose
+          no_output_timeout: 30m
       - save_cache:
-          key: v1-bundle-{{ checksum "Gemfile.lock" }}
+          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
           paths:
             - ~/test/vendor/bundle
 
@@ -85,7 +88,7 @@ jobs:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-bundle-{{ checksum "Gemfile.lock" }}
+          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
@@ -132,12 +135,12 @@ jobs:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-bundle-{{ checksum "Gemfile.lock" }}
+          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
-      - run: gem install bundler
+      - run: gem install bundler:2.3.17
       - run: bundle config set path 'vendor/bundle'
       - run: bundle exec rake i18n:js:export
       - run: yarn install
@@ -166,8 +169,8 @@ jobs:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-bundle-{{ checksum "Gemfile.lock" }}
-      - run: gem install bundler
+          key: v2-bundle-ruby34-{{ checksum "Gemfile.lock" }}
+      - run: gem install bundler:2.3.17
       - run: bundle config set path 'vendor/bundle'
       - run: bundle exec rubocop
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
-      - run: gem install bundler
+      - run: gem install bundler:2.3.17
       - run: bundle config set path 'vendor/bundle'
       - run: bundle install --jobs=4 --retry=3
       - save_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Building stage
 #===============
-FROM ruby:3.2.3
+FROM ruby:3.3.11
 
 ARG precompileassets
 # set from --build-arg
@@ -8,14 +8,12 @@ ARG PROJECT_NAME
 ARG RAILS_ENV
 ARG NODE_ENV
 
-# Needed for Yarn
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev curl software-properties-common && \
+# Needed for Node and Yarn Classic
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev curl && \
   curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
   apt-get update && \
-  apt-get install -y nodejs yarn && \
-  apt-get remove -y --purge software-properties-common &&\
+  apt-get install -y nodejs && \
+  corepack enable && corepack prepare yarn@1.22.22 --activate && \
   rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app
@@ -28,7 +26,7 @@ RUN yarn install --check-files
 
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
-RUN bundle config --global frozen 1 \
+RUN bundle config set --global frozen 1 \
   && bundle install \
   && rm -rf /usr/local/bundle/bundler/gems/*/.git \
     /usr/local/bundle/cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Building stage
 #===============
-FROM ruby:3.3.11
+FROM ruby:3.4.9
 
 ARG precompileassets
 # set from --build-arg

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Specify ruby version for heroku
-ruby '3.3.11'
+ruby '3.4.9'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 8.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Specify ruby version for heroku
-ruby '3.2.3'
+ruby '3.3.11'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 8.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,7 +713,7 @@ DEPENDENCIES
   webpacker (>= 6.0.0.rc.5)
 
 RUBY VERSION
-   ruby 3.3.11p205
+   ruby 3.4.9p82
 
 BUNDLED WITH
    2.3.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,7 +713,7 @@ DEPENDENCIES
   webpacker (>= 6.0.0.rc.5)
 
 RUBY VERSION
-   ruby 3.2.3p157
+   ruby 3.3.11p205
 
 BUNDLED WITH
    2.3.17

--- a/spec/logic/questionnaire_expander_spec.rb
+++ b/spec/logic/questionnaire_expander_spec.rb
@@ -181,7 +181,7 @@ describe QuestionnaireExpander do
                       { title: 'pizza' }
                     ] }
         expect { described_class.expand_content(content, response) }
-          .to raise_error(RuntimeError, "Only :previous uses type is allowed, not '{:mentor=>\"abc\"}'")
+          .to raise_error(RuntimeError, "Only :previous uses type is allowed, not '{mentor: \"abc\"}'")
       end
 
       it 'returns an array' do

--- a/spec/use_cases/echo_people_spec.rb
+++ b/spec/use_cases/echo_people_spec.rb
@@ -55,21 +55,21 @@ describe EchoPeople do
 
       it 'returns an array with all people (except the header)' do
         expected_output = "people = [];nil\n"
-        expected_output += 'people << {:team_name=>"mijnschool", :role_title=>"x", :first_name=>"a", ' \
-                           ':last_name=>"e", :gender=>"male", :mobile_phone=>"0612345679", ' \
-                           ':email=>"email1@email.com", ' \
-                           ":protocol_name=>\"protname\", :start_date=>\"#{dateinfuture}\", " \
-                           ":end_date=>\"#{enddateinfuture}\"};nil\n"
-        expected_output += 'people << {:team_name=>"mijnschool", :role_title=>"y", :first_name=>"b", ' \
-                           ':last_name=>"f", :gender=>"female", :mobile_phone=>"06-12345670", ' \
-                           ':email=>"email2@email.com", ' \
-                           ":protocol_name=>\"protname\", :start_date=>\"#{dateinfuture}\", " \
-                           ":end_date=>\"#{enddateinfuture}\"};nil\n"
-        expected_output += 'people << {:team_name=>"mijnschool", :role_title=>"z", :first_name=>"c", ' \
-                           ':last_name=>"g", :gender=>"male", :mobile_phone=>"0612345671", ' \
-                           ':email=>"email3@email.com", ' \
-                           ":protocol_name=>\"protname\", :start_date=>\"#{dateinfuture}\", " \
-                           ":end_date=>\"#{enddateinfuture}\"};nil\n"
+        expected_output += 'people << {team_name: "mijnschool", role_title: "x", first_name: "a", ' \
+                           'last_name: "e", gender: "male", mobile_phone: "0612345679", ' \
+                           'email: "email1@email.com", ' \
+                           "protocol_name: \"protname\", start_date: \"#{dateinfuture}\", " \
+                           "end_date: \"#{enddateinfuture}\"};nil\n"
+        expected_output += 'people << {team_name: "mijnschool", role_title: "y", first_name: "b", ' \
+                           'last_name: "f", gender: "female", mobile_phone: "06-12345670", ' \
+                           'email: "email2@email.com", ' \
+                           "protocol_name: \"protname\", start_date: \"#{dateinfuture}\", " \
+                           "end_date: \"#{enddateinfuture}\"};nil\n"
+        expected_output += 'people << {team_name: "mijnschool", role_title: "z", first_name: "c", ' \
+                           'last_name: "g", gender: "male", mobile_phone: "0612345671", ' \
+                           'email: "email3@email.com", ' \
+                           "protocol_name: \"protname\", start_date: \"#{dateinfuture}\", " \
+                           "end_date: \"#{enddateinfuture}\"};nil\n"
         expect { subject.send(:echo_people, 'test.csv') }.to output(expected_output).to_stdout
       end
     end
@@ -99,41 +99,41 @@ describe EchoPeople do
 
       it 'returns an array with all mentors (except the header)' do
         expected_output = "people = [];nil\n"
-        expected_output += 'people << {:team_name=>"jouwschool", ' \
-                           ':role_title=>"Mentor", :first_name=>"a", :last_name=>"e", ' \
-                           ':gender=>"male", :mobile_phone=>"0612345679", ' \
-                           ':email=>"mentor1@test.com", :protocol_name=>"protname", ' \
-                           ":start_date=>\"#{dateinfuture}\", " \
-                           ':filling_out_for=>"06-12345670", :filling_out_for_protocol=>"pilot", ' \
-                           ":end_date=>\"#{enddateinfuture}\"};nil\n"
-        expected_output += 'people << {:team_name=>"jouwschool", ' \
-                           ':role_title=>"Mentor", :first_name=>"a", :last_name=>"e", ' \
-                           ':gender=>"female", :mobile_phone=>"0612345679", ' \
-                           ':email=>"mentor2@test.com", :protocol_name=>"protname", ' \
-                           ":start_date=>\"#{dateinfuture}\", " \
-                           ':filling_out_for=>"0676543219", :filling_out_for_protocol=>"pilot", ' \
-                           ":end_date=>\"#{enddateinfuture}\"};nil\n"
-        expected_output += 'people << {:team_name=>"jouwschool", ' \
-                           ':role_title=>"Mentor", :first_name=>"b", :last_name=>"f", ' \
-                           ':gender=>"male", :mobile_phone=>"06-12345670", ' \
-                           ':email=>"mentor3@test.com", :protocol_name=>"protname", ' \
-                           ":start_date=>\"#{dateinfuture}\", " \
-                           ':filling_out_for=>"0676543219", :filling_out_for_protocol=>"pilot", ' \
-                           ":end_date=>\"#{enddateinfuture}\"};nil\n"
-        expected_output += 'people << {:team_name=>"jouwschool", ' \
-                           ':role_title=>"Mentor", :first_name=>"b", :last_name=>"f", ' \
-                           ':gender=>"female", :mobile_phone=>"06-12345670", ' \
-                           ':email=>"mentor4@test.com", :protocol_name=>"protname", ' \
-                           ":start_date=>\"#{dateinfuture}\", " \
-                           ':filling_out_for=>"0676543266", :filling_out_for_protocol=>"pilot", ' \
-                           ":end_date=>\"#{enddateinfuture}\"};nil\n"
-        expected_output += 'people << {:team_name=>"jouwschool", ' \
-                           ':role_title=>"Mentor", :first_name=>"b", :last_name=>"f", ' \
-                           ':gender=>"male", :mobile_phone=>"06-12345670", ' \
-                           ':email=>"mentor5@test.com", :protocol_name=>"protname", ' \
-                           ":start_date=>\"#{dateinfuture}\", " \
-                           ':filling_out_for=>"0676543227", :filling_out_for_protocol=>"pilot", ' \
-                           ":end_date=>\"#{enddateinfuture}\"};nil\n"
+        expected_output += 'people << {team_name: "jouwschool", ' \
+                           'role_title: "Mentor", first_name: "a", last_name: "e", ' \
+                           'gender: "male", mobile_phone: "0612345679", ' \
+                           'email: "mentor1@test.com", protocol_name: "protname", ' \
+                           "start_date: \"#{dateinfuture}\", " \
+                           'filling_out_for: "06-12345670", filling_out_for_protocol: "pilot", ' \
+                           "end_date: \"#{enddateinfuture}\"};nil\n"
+        expected_output += 'people << {team_name: "jouwschool", ' \
+                           'role_title: "Mentor", first_name: "a", last_name: "e", ' \
+                           'gender: "female", mobile_phone: "0612345679", ' \
+                           'email: "mentor2@test.com", protocol_name: "protname", ' \
+                           "start_date: \"#{dateinfuture}\", " \
+                           'filling_out_for: "0676543219", filling_out_for_protocol: "pilot", ' \
+                           "end_date: \"#{enddateinfuture}\"};nil\n"
+        expected_output += 'people << {team_name: "jouwschool", ' \
+                           'role_title: "Mentor", first_name: "b", last_name: "f", ' \
+                           'gender: "male", mobile_phone: "06-12345670", ' \
+                           'email: "mentor3@test.com", protocol_name: "protname", ' \
+                           "start_date: \"#{dateinfuture}\", " \
+                           'filling_out_for: "0676543219", filling_out_for_protocol: "pilot", ' \
+                           "end_date: \"#{enddateinfuture}\"};nil\n"
+        expected_output += 'people << {team_name: "jouwschool", ' \
+                           'role_title: "Mentor", first_name: "b", last_name: "f", ' \
+                           'gender: "female", mobile_phone: "06-12345670", ' \
+                           'email: "mentor4@test.com", protocol_name: "protname", ' \
+                           "start_date: \"#{dateinfuture}\", " \
+                           'filling_out_for: "0676543266", filling_out_for_protocol: "pilot", ' \
+                           "end_date: \"#{enddateinfuture}\"};nil\n"
+        expected_output += 'people << {team_name: "jouwschool", ' \
+                           'role_title: "Mentor", first_name: "b", last_name: "f", ' \
+                           'gender: "male", mobile_phone: "06-12345670", ' \
+                           'email: "mentor5@test.com", protocol_name: "protname", ' \
+                           "start_date: \"#{dateinfuture}\", " \
+                           'filling_out_for: "0676543227", filling_out_for_protocol: "pilot", ' \
+                           "end_date: \"#{enddateinfuture}\"};nil\n"
 
         expect { subject.send(:echo_people, 'test.csv') }.to output(expected_output).to_stdout
       end


### PR DESCRIPTION
Ruby 3.4 changed Hash#inspect output from `{:key=>"value"}` to `{key: "value"}`. This PR updates the test expectations in `questionnaire_expander_spec` and `echo_people_spec` to match the new format, fixing 3 test failures on the `feature/mr-upgrade-rails` branch.