### PR TITLE
feat: add mobile compatibility to likert and range questions

### DIFF
--- a/app/assets/stylesheets/questionnaire.scss
+++ b/app/assets/stylesheets/questionnaire.scss
@@ -315,33 +315,6 @@ $vertical-range-padding-top: 8px;
       }
     }
   }
-
-  // Ranges with 3+ labels (e.g. KCCQ): hiding the middle labels loses the
-  // meaning of the intermediate values, so list every label as a
-  // "value – text" legend instead. The slider JS toggles .active on the
-  // label matching the current value.
-  .col .row.label-row .col:first-child:nth-last-child(n + 3),
-  .col .row.label-row .col:first-child:nth-last-child(n + 3) ~ .col {
-    display: block;
-    // !important to beat the generator's inline width style
-    width: 100% !important;
-    float: none;
-    text-align: left;
-    padding: 1px 0;
-    // The desktop layout nudges the edge labels outward to line up with the
-    // slider ends; in a stacked list that just skews the first and last rows.
-    transform: none;
-
-    &:before {
-      content: attr(data-value) ' – ';
-      font-weight: 600;
-    }
-
-    &.active {
-      color: $accent-color;
-      font-weight: 700;
-    }
-  }
 }
 
 

--- a/app/assets/stylesheets/questionnaire.scss
+++ b/app/assets/stylesheets/questionnaire.scss
@@ -315,6 +315,33 @@ $vertical-range-padding-top: 8px;
       }
     }
   }
+
+  // Ranges with 3+ labels (e.g. KCCQ): hiding the middle labels loses the
+  // meaning of the intermediate values, so list every label as a
+  // "value – text" legend instead. The slider JS toggles .active on the
+  // label matching the current value.
+  .col .row.label-row .col:first-child:nth-last-child(n + 3),
+  .col .row.label-row .col:first-child:nth-last-child(n + 3) ~ .col {
+    display: block;
+    // !important to beat the generator's inline width style
+    width: 100% !important;
+    float: none;
+    text-align: left;
+    padding: 1px 0;
+    // The desktop layout nudges the edge labels outward to line up with the
+    // slider ends; in a stacked list that just skews the first and last rows.
+    transform: none;
+
+    &:before {
+      content: attr(data-value) ' – ';
+      font-weight: 600;
+    }
+
+    &.active {
+      color: $accent-color;
+      font-weight: 700;
+    }
+  }
 }
 
 
@@ -542,6 +569,44 @@ button[type="submit"] {
        width: 100%;
       text-align: center;
       vertical-align: center;
+      // Materialize gives radio spans a fixed 25px height; without this,
+      // labels that wrap onto multiple lines paint over the question below.
+      // !important because Materialize's [type="radio"] + span selector
+      // outweighs this one, like the display/padding overrides above.
+      height: auto !important;
+    }
+  }
+}
+
+// A full likert row of 5-7 options cannot fit on narrow screens (it overflows
+// the viewport), so stack the options vertically like a regular radio list.
+@media only screen and (max-width: 700px) {
+  form .likert-scale {
+    display: block;
+  }
+
+  .likert-item {
+    text-align: left;
+
+    p {
+      padding-left: 35px;
+    }
+
+    label span {
+      display: inline !important;
+      width: auto;
+      padding: 0 !important;
+      text-align: left;
+
+      &:before, &:after {
+        position: absolute;
+        top: -0.2rem !important;
+        left: -35px !important;
+        bottom: auto;
+        right: auto;
+        margin: 0;
+        padding: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Likert scales rendered as a single no-wrap flex row at every screen width, so 5-7 option scales overflowed phone viewports, and Materialize's fixed 25px radio-span height made wrapped option labels paint over the question below. Below 700px the options now stack vertically like a regular radio list, and spans grow with their text at all widths.

Range questions with 3+ labels now list every label as a 'value - text' legend on mobile instead of hiding the middle labels.
https://claude.ai/code/artifact/0ed8a904-60df-4a5e-b861-8a15cbd7bf70