### PR TITLE
fix(ci): declare stage and use rules on build_web_job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,12 +31,12 @@ variables:
 
 build_web_job:
   extends: .buildah:build
+  stage: build
   variables:
     BUILD_ARG_PROJECT_NAME: $PROJECT_NAME
     BUILD_ARG_RAILS_ENV: production
     BUILD_ARG_NODE_ENV: production
-  only:
-    refs:
-      - master
-      - production
-      - develop
+  # rules (not only/except) because the buildah component defines rules, and
+  # GitLab forbids mixing rules with only/except in one job.
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "master" || $CI_COMMIT_REF_NAME == "production" || $CI_COMMIT_REF_NAME == "develop"'


### PR DESCRIPTION
## Why

Follow-up to #4063. That fix swapped `build_web_job` onto the buildah CI/CD component, but the very next pipeline (commit 887d027d) failed at config-validation, before any job ran:

```
jobs:build_web_job config key may not be used with `rules`: only
```

Confirmed via the project's CI lint API against 887d027d — after fixing that, lint also caught:

```
build_web_job job: chosen stage test does not exist; available stages are .pre, build, release, .post
```

## What changed

- `.buildah:build` sets a default `rules: [{when: on_success}]`. GitLab forbids mixing `rules` with `only`/`except` on the same job (even a single job, not just across jobs). Replaced `only: refs: [master, production, develop]` with an equivalent `rules:` condition — same pattern Researchable's `base-platform` pipeline already uses for its own buildah jobs.
- Unlike the old `.docker_build_job` template, `.buildah:build` doesn't set `stage:` itself — it's left to the caller (again, matching `base-platform`). Without it the job implicitly defaults to GitLab's built-in `test` stage, which this pipeline doesn't declare. Added `stage: build`.

## Worth knowing when reviewing

Verified via `POST /projects/:id/ci/lint` against the actual merged config on Researchable's GitLab mirror (`valid: true`, no errors) rather than just reading the YAML — the component's `rules:`/`stage:` behavior only shows up after merge, not by inspecting this file in isolation.

## Tests

No app code touched. CI lint confirms the merged pipeline config is valid; the real verification is the next pipeline run on `develop` after merge.