### PR TITLE
fix(docker): fully qualify the ruby base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Building stage
 #===============
-FROM ruby:3.4.9
+FROM docker.io/library/ruby:3.4.9
 
 ARG precompileassets
 # set from --build-arg


### PR DESCRIPTION
## Why

Follow-up to #4063/#4064. With the pipeline config fixed, `build_web_job` now actually runs and reaches the image build -- and fails there:

```
STEP 1/23: FROM ruby:3.4.9
Error: creating build container: short-name resolution enforced but cannot prompt without a TTY
```

`docker build`/kaniko silently assumed Docker Hub for the unqualified `ruby:3.4.9`. buildah enforces short-name resolution by default and, with no TTY in a CI job, can't prompt to disambiguate -- it just errors.

## What changed

Qualified the base image to `docker.io/library/ruby:3.4.9` in the Dockerfile. Same image (Docker Hub's official `ruby` image lives under the `library/` namespace), no behavior change for local `docker`/`docker-compose` use -- just explicit for buildah.

## Tests

No app code touched. Verification is the next `develop` pipeline run.